### PR TITLE
Add the `/disablereplytoggle` and `/enablereplytoggle` commands

### DIFF
--- a/Spectre.py
+++ b/Spectre.py
@@ -10,12 +10,14 @@ INTENTS = discord.Intents.default()
 INTENTS.message_content = True
 
 config = util.JsonHandler.load_json("config.json")
+log_data = {}
 
 # Config docs
 # {
 #     "admin": <admin id>,
 #     "cooldowntime": <cooldown seconds>, 
 #     "noreplylist": <name of list.json>,
+#     "neverreplylist": <name of neverreplylist.json>
 #     "allowedchannels": <name of list.json>
 # }
 
@@ -62,6 +64,37 @@ async def reload(ctx):
         for cog in COGS:
             await bot.reload_extension(cog)
         print('Reloaded cogs successfully!')
+    else:
+        await ctx.send("You don't have permission to use this command!", ephemeral=True)
+
+# Disable a user's automatic replies if they're being naughty :D
+@bot.hybrid_command(description="Disables reply toggling for selected user. Owner only.")
+@app_commands.describe(user = "The user to disable reply toggling for")
+async def disablereplytoggle(ctx, user: discord.Member):
+    if ctx.author.id == bot.owner_id:
+        data = util.JsonHandler.load_neverusers()
+        log_data[str(user.id)] = "off"
+        # This isn't very efficient but it works (I think)!
+        util.JsonHandler.save_neverusers(log_data)
+        await ctx.send(f"Successfully disabled reply toggling for {user}", ephemeral=True)
+    else:
+        await ctx.send("You don't have permission to use this command!", ephemeral=True)
+
+# Enables giving users control over automatic responses for them again
+@bot.hybrid_command(description="Enables reply toggling for selected user. Owner only.")
+@app_commands.describe(user = "The user to enable reply toggling for")
+async def enablereplytoggle(ctx, user: discord.Member):
+    if ctx.author.id == bot.owner_id:
+        data = util.JsonHandler.load_neverusers()
+
+        for key in data:
+            if str(user.id) in data:
+                del data[str(user.id)]
+                # This isn't very efficient but it works (I think)!
+                await ctx.send(f"Successfully disabled reply toggling for {user}", ephemeral=True)
+                break
+        
+        util.JsonHandler.save_neverusers(data)
     else:
         await ctx.send("You don't have permission to use this command!", ephemeral=True)
 

--- a/cogs/AutoResponse.py
+++ b/cogs/AutoResponse.py
@@ -52,6 +52,7 @@ class AutoResponse(commands.Cog):
     async def on_message(self, message):
         view = SimpleView()
         users = util.JsonHandler.load_users()
+        neverusers = util.JsonHandler.load_neverusers()
         channel = util.JsonHandler.load_channels()
         time_diff = (datetime.datetime.utcnow() - self.last_time).total_seconds()
 
@@ -63,7 +64,9 @@ class AutoResponse(commands.Cog):
         else:
             if replycheck() == True:
                 if str(message.author.id) in users:
-                    if str(message.author.id) == False:
+                        return
+                    
+                if str(message.author.id) in neverusers:
                         return
                 
                 if str(message.channel.id) in channel:

--- a/cogs/UserReplies.py
+++ b/cogs/UserReplies.py
@@ -13,8 +13,8 @@ class UserReplies(commands.Cog):
     @commands.hybrid_command(name='disablereplies', description='Disables replies for the user who uses the command')
     async def disablereplies(self, ctx):
         data = util.JsonHandler.load_users()
-        log_data[str(ctx.author.id)] = {}
-        log_data[str(ctx.author.id)] = False
+        log_data[str(ctx.author.id)] = "off"
+        # This isn't very efficient but it works (I think)!
         util.JsonHandler.save_users(log_data)
         await ctx.send("Successfully disabled me automatically replying to your messages!", ephemeral=True)
 

--- a/config.json
+++ b/config.json
@@ -3,5 +3,6 @@
     "prefix": "$",
     "cooldowntime": 5, 
     "noreplylist": "noreplyusers.json",
+    "neverreplylist": "neverreplyusers.json",
     "allowedchannels": "allowedchannels.json"
 }

--- a/util/JsonHandler.py
+++ b/util/JsonHandler.py
@@ -23,12 +23,21 @@ def load_json(file):
         data = json.load(f)
     return data
     
+# Functions for saving users toggling their replies to JSON
 def save_users(data):
     save_json(noreplylist, data)
 
 def load_users():
     return load_json(noreplylist)
 
+# Functions for saving me toggling user abilities to toggle replies to JSON
+def save_neverusers(data):
+    save_json(neverreplylist, data)
+
+def load_neverusers():
+    return load_json(neverreplylist)
+
+# Functions for saving allowed channels to JSON
 def save_channels(data):
     save_json(allowedchannels, data)
 
@@ -38,4 +47,5 @@ def load_channels():
 
 config = load_json("config.json")
 noreplylist = config["noreplylist"]
+neverreplylist = config["neverreplylist"]
 allowedchannels = config["allowedchannels"]


### PR DESCRIPTION
Commands to let me manually disable allowing users to freely change the status of their automatic replies. Only to be used when someone is abusing the bot