### PR TITLE
Data log mini "overhaul"

### DIFF
--- a/cogs/AllowedChannels.py
+++ b/cogs/AllowedChannels.py
@@ -13,7 +13,7 @@ class AllowedChannels(commands.Cog):
 
         if str(ctx.author.id) in allowed_users:
             data = util.JsonHandler.load_channels()
-            data[str(ctx.channel.id)] = "Enabled"
+            data[str(ctx.channel.id)] = ""
             util.JsonHandler.save_channels(data)
             
             await ctx.send("Successfully enabled automatic replies in this channel!")

--- a/cogs/AllowedChannels.py
+++ b/cogs/AllowedChannels.py
@@ -13,7 +13,7 @@ class AllowedChannels(commands.Cog):
 
         if str(ctx.author.id) in allowed_users:
             data = util.JsonHandler.load_channels()
-            data[str(ctx.channel.id)] = ""
+            data[str(ctx.channel.id)] = f"{ctx.guild.name} - {ctx.channel.name}"
             util.JsonHandler.save_channels(data)
             
             await ctx.send("Successfully enabled automatic replies in this channel!")

--- a/cogs/AutoResponse.py
+++ b/cogs/AutoResponse.py
@@ -53,7 +53,7 @@ class ToggleRepliesButton(discord.ui.View):
                 await interaction.response.send_message("Successfully enabled automatic replies!", ephemeral=True)
                 break
         else:
-            data[str(interaction.user.id)] = "off"
+            data[str(interaction.user.id)] = f"{interaction.user.display_name}"
             await interaction.response.send_message("Successfully disabled automatic replies!", ephemeral=True)
 
         util.JsonHandler.save_users(data)

--- a/cogs/UserReplies.py
+++ b/cogs/UserReplies.py
@@ -16,7 +16,7 @@ class UserReplies(commands.Cog):
             await ctx.send("You already have automatic replies disabled!", ephemeral=True)
             
         else:    
-            data[str(ctx.author.id)] = "off"
+            data[str(ctx.author.id)] = f"{interaction.user.display_name}"
 
             util.JsonHandler.save_users(data)
             await ctx.send("Successfully disabled me automatically replying to your messages!", ephemeral=True)


### PR DESCRIPTION
Makes the data logging commands log more info

User replies log the user's display name, while allowed channels log the server name alongside the channel that it's enabled on in that server