### PR TITLE
Add "auto update" functionality

### DIFF
--- a/config.json
+++ b/config.json
@@ -2,8 +2,8 @@
     "admin": 502519988423229460,
     "prefix": "$",
     "cooldowntime": 5, 
-    "noreplylist": "noreplyusers.json",
-    "neverreplylist": "neverreplyusers.json",
-    "allowedchannels": "allowedchannels.json",
-    "allowedusers": "allowedusers.json"
+    "noreplylist": "data/noreplyusers.json",
+    "neverreplylist": "data/neverreplyusers.json",
+    "allowedchannels": "data/allowedchannels.json",
+    "allowedusers": "data/allowedusers.json"
 }

--- a/updateSpectre.py
+++ b/updateSpectre.py
@@ -1,0 +1,45 @@
+import os
+import shutil
+from git.repo.base import Repo
+
+# Check that we're actually in the Spectre directory
+if os.path.isfile("Spectre.py") == True:
+    # Check that data exists. This could still error out if you don't have one of the other two, but if you don't, what are you doing
+    if os.path.exists("data") == True:
+        if os.path.exists("../SpectreData") == False:
+            os.mkdir("../SpectreData")
+            
+        # Code to copy existing data files to a temporary directory
+        shutil.move("data", "../SpectreData/data")
+        shutil.move(".env", "../SpectreData")
+        shutil.move("config.json", "../SpectreData")
+        
+        # Move to the parent directory (to create the new directory and later delete the old ones)
+        os.chdir("../")
+        os.rename("Spectre", "SpectreOld")
+        os.mkdir("Spectre")
+        
+        # Clone the newest GitHub repo version
+        Repo.clone_from("https://github.com/CooldudePUGS/Spectre", "Spectre")
+        
+        # Remove the "new" config file. There might be a better way to do this, but this works
+        os.remove("Spectre/config.json")
+        
+        # Move the old data files from the temporary folder into the new Spectre folder
+        shutil.move("SpectreData/data", "Spectre/data")
+        shutil.move("SpectreData/.env", "Spectre")
+        shutil.move("SpectreData/config.json", "Spectre")
+        
+        # Print that the system hasn't imploded yet
+        print("Moved Spectre's data files succesfully!")
+        print("Deleting old Spectre files...")
+        
+        # Remove temporary folders
+        shutil.rmtree("SpectreOld")
+        shutil.rmtree("SpectreData")
+    else:
+        print("Run the file inside the OLD Spectre directory that has your data!")
+else:
+    print("Run the file inside the Spectre directory!")
+    
+# Yes, this uses both shutil and os. I'm really not sure if this is fine or a "sin" to programmers. I did this because os wouldn't accept me moving the .env file properly.


### PR DESCRIPTION
This pr allows you to run `python3 updateSpectre.py`, which will take all of the relevant data files (the allowed users, channels, no replies and never replies, the `.env` file with your token, and your `config.json` file), place them into a temporary data folders, download the newest Spectre repo version, move your old data files into the new version, then delete the temporary data folders.

This is mostly meant for me, lol. I got tired of having to move all this manually/start over every time. It also seems to accidentally download the repo about 3 times faster than GitHub cli? For me, at least. I'll test this right after merging because it all works, so far. Yet to test with an updated repo but not sure why it _wouldn't_ work.