### PR TITLE
Paginated thunderstore mod searching

### DIFF
--- a/Spectre.py
+++ b/Spectre.py
@@ -4,7 +4,7 @@ import util.JsonHandler
 from discord.ext import commands
 from dotenv import load_dotenv
 
-COGS = ("cogs.AutoResponse", "cogs.GlobalReplies", "cogs.UserReplies", "cogs.InstallChannelEmbed", "cogs.AllowedChannels", "cogs.LogReading", "cogs.PriceCheck", "cogs.AllowedUsers", "cogs.HelpCommand", "cogs.MasterCheck")
+COGS = ("cogs.AutoResponse", "cogs.GlobalReplies", "cogs.UserReplies", "cogs.InstallChannelEmbed", "cogs.AllowedChannels", "cogs.LogReading", "cogs.PriceCheck", "cogs.AllowedUsers", "cogs.HelpCommand", "cogs.MasterCheck", "cogs.ModSearch")
 INTENTS = discord.Intents.default()
 INTENTS.message_content = True
 

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -43,7 +43,7 @@ class ModSearch(commands.Cog):
                     "owner": item['owner'],
                     "icon_url": item['versions'][0]['icon'],
                     "dl_url": item['versions'][0]['download_url'],
-                    "last_update": item['date_updated'],
+                    "last_update": item['date_updated'][:(item['date_updated'].index('T'))], # Remove time from date string
                     "total_dl": downloads,
                     "description": item['versions'][0]['description']
                 }

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -7,81 +7,90 @@ class ModSearch(commands.Cog):
     def __init__(self, bot :commands.Bot) -> None:
         self.bot = bot
         
+    should_search = True
+        
     @commands.hybrid_command(description="Search Northstar Thunderstore for mods")
     async def searchts(self, ctx, search_string: str):
-        try:
-            response = requests.get("https://northstar.thunderstore.io/api/v1/package/")
-            if response.status_code == 200:
-                data = response.json()
-        
-        except requests.exceptions.RequestException as err:
-            print(err)
-            return
-        
-        mods = {}
-        for i, item in enumerate(data):
-            match = re.search(search_string, item["name"], re.IGNORECASE)
-            if match:
-                downloads = 0
-                for version in item['versions']:
-                    downloads = downloads + version['downloads']
-                mods["result_" + str(i)] = {
-                    "name": item['name'],
-                    "owner": item['owner'],
-                    "icon_url": item['versions'][0]['icon'],
-                    "dl_url": item['versions'][0]['download_url'],
-                    "last_update": item['date_updated'],
-                    "total_dl": downloads,
-                    "description": item['versions'][0]['description']
-                }
-        
-        # Sort mods by most downloaded by default until we get better sorting later        
-        sorted_mods_by_dl = dict(sorted(mods.items(), key=lambda item: item[1]['total_dl'], reverse=True))
-        
-        pages = list(sorted_mods_by_dl.keys())
-        current_page = 0
-        
-        def get_mod_embed():
-            key = pages[current_page]
-            mod = sorted_mods_by_dl[key]
-            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownloads: {mod['total_dl']}\n{mod['dl_url']}"
-            embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
-            embed = discord.Embed(
-                title=embed_title,
-                description=mod_embed_desc
-            )
-            embed.set_thumbnail(url=mod['icon_url'])
-            return embed
-        
-        message = await ctx.send(embed=get_mod_embed())
-        reactions = ['⏮️', '◀️', '▶️', '⏭️']
-        for reaction in reactions:
-            await message.add_reaction(reaction)
-            sleep(0.100) # Sleep for 100ms to hopefully avoid reactions getting placed out-of-order
-            
-        def check_react(reaction, user):
-            return user == ctx.author and str(reaction.emoji) in reactions
-        
-        while True:
+        if should_search:
             try:
-                reaction, _ = await self.bot.wait_for('reaction_add', timeout=60.0, check=check_react)
-                
-                if str(reaction.emoji) == '⏮️':
-                    current_page = 0
-                elif str(reaction.emoji) == '◀️':
-                    current_page = (current_page - 1) % len(pages)
-                elif str(reaction.emoji) == '▶️':
-                    current_page = (current_page + 1) % len(pages)
-                elif str(reaction.emoji) == '⏭️':
-                    current_page = len(pages) - 1
-                
-                await message.edit(embed=get_mod_embed())
-                await message.remove_reaction(reaction, ctx.author)
-                
-            except asyncio.TimeoutError:
-                break
+                response = requests.get("https://northstar.thunderstore.io/api/v1/package/")
+                if response.status_code == 200:
+                    data = response.json()
             
-        await message.clear_reactions()              
+            except requests.exceptions.RequestException as err:
+                print(err)
+                return
+            
+            mods = {}
+            for i, item in enumerate(data):
+                match = re.search(search_string, item["name"], re.IGNORECASE)
+                if match:
+                    downloads = 0
+                    for version in item['versions']:
+                        downloads = downloads + version['downloads']
+                    mods["result_" + str(i)] = {
+                        "name": item['name'],
+                        "owner": item['owner'],
+                        "icon_url": item['versions'][0]['icon'],
+                        "dl_url": item['versions'][0]['download_url'],
+                        "last_update": item['date_updated'],
+                        "total_dl": downloads,
+                        "description": item['versions'][0]['description']
+                    }
+            
+            # Sort mods by most downloaded by default until we get better sorting later        
+            sorted_mods_by_dl = dict(sorted(mods.items(), key=lambda item: item[1]['total_dl'], reverse=True))
+            
+            pages = list(sorted_mods_by_dl.keys())
+            current_page = 0
+            
+            def get_mod_embed():
+                key = pages[current_page]
+                mod = sorted_mods_by_dl[key]
+                mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownloads: {mod['total_dl']}\n{mod['dl_url']}"
+                embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
+                embed = discord.Embed(
+                    title=embed_title,
+                    description=mod_embed_desc
+                )
+                embed.set_thumbnail(url=mod['icon_url'])
+                return embed
+            
+            message = await ctx.send(embed=get_mod_embed())
+            reactions = ['⏮️', '◀️', '▶️', '⏭️']
+            for reaction in reactions:
+                await message.add_reaction(reaction)
+                sleep(0.100) # Sleep for 100ms to hopefully avoid reactions getting placed out-of-order
+                
+            def check_react(reaction, user):
+                return user == ctx.author and str(reaction.emoji) in reactions
+            
+            while True:
+                should_search = False
+                try:
+                    reaction, _ = await self.bot.wait_for('reaction_add', timeout=60.0, check=check_react)
+                    
+                    if str(reaction.emoji) == '⏮️':
+                        current_page = 0
+                    elif str(reaction.emoji) == '◀️':
+                        current_page = (current_page - 1) % len(pages)
+                    elif str(reaction.emoji) == '▶️':
+                        current_page = (current_page + 1) % len(pages)
+                    elif str(reaction.emoji) == '⏭️':
+                        current_page = len(pages) - 1
+                    
+                    await message.edit(embed=get_mod_embed())
+                    await message.remove_reaction(reaction, ctx.author)
+                    
+                except asyncio.TimeoutError:
+                    break
+                
+            await message.clear_reactions()
+            should_search = True
+            return
+        else:
+            await ctx.send("Please wait for previous search to timeout")
+            return
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(ModSearch(bot))

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -7,90 +7,91 @@ class ModSearch(commands.Cog):
     def __init__(self, bot :commands.Bot) -> None:
         self.bot = bot
         
-    should_search = True
-        
     @commands.hybrid_command(description="Search Northstar Thunderstore for mods")
     async def searchts(self, ctx, search_string: str):
-        if should_search:
+        if active_search:
+            await ctx.send("Please wait for the active search to timeout")
+            return
+        
+        try:
+            response = requests.get("https://northstar.thunderstore.io/api/v1/package/")
+            if response.status_code == 200:
+                data = response.json()
+        
+        except requests.exceptions.RequestException as err:
+            print(err)
+            return
+        
+        mods = {}
+        for i, item in enumerate(data):
+            match = re.search(search_string, item["name"], re.IGNORECASE)
+            if match:
+                downloads = 0
+                for version in item['versions']:
+                    downloads = downloads + version['downloads']
+                mods["result_" + str(i)] = {
+                    "name": item['name'].replace("_", " "),
+                    "owner": item['owner'],
+                    "icon_url": item['versions'][0]['icon'],
+                    "dl_url": item['versions'][0]['download_url'],
+                    "last_update": item['date_updated'],
+                    "total_dl": downloads,
+                    "description": item['versions'][0]['description']
+                }
+        
+        # Sort mods by most downloaded by default until we get better sorting later        
+        sorted_mods_by_dl = dict(sorted(mods.items(), key=lambda item: item[1]['total_dl'], reverse=True))
+        
+        pages = list(sorted_mods_by_dl.keys())
+        current_page = 0
+        
+        def get_mod_embed():
+            key = pages[current_page]
+            mod = sorted_mods_by_dl[key]
+            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownloads: {mod['total_dl']}\n{mod['dl_url']}"
+            embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
+            embed = discord.Embed(
+                title=embed_title,
+                description=mod_embed_desc
+            )
+            embed.set_thumbnail(url=mod['icon_url'])
+            return embed
+        
+        message = await ctx.send(embed=get_mod_embed())
+        
+        active_search = True
+        
+        reactions = ['⏮️', '◀️', '▶️', '⏭️']
+        for reaction in reactions:
+            await message.add_reaction(reaction)
+            sleep(0.100) # Sleep for 100ms to hopefully avoid reactions getting placed out-of-order
+            
+        def check_react(reaction, user):
+            return user == ctx.author and str(reaction.emoji) in reactions
+        
+        while True:
             try:
-                response = requests.get("https://northstar.thunderstore.io/api/v1/package/")
-                if response.status_code == 200:
-                    data = response.json()
-            
-            except requests.exceptions.RequestException as err:
-                print(err)
-                return
-            
-            mods = {}
-            for i, item in enumerate(data):
-                match = re.search(search_string, item["name"], re.IGNORECASE)
-                if match:
-                    downloads = 0
-                    for version in item['versions']:
-                        downloads = downloads + version['downloads']
-                    mods["result_" + str(i)] = {
-                        "name": item['name'].replace("_", " "),
-                        "owner": item['owner'],
-                        "icon_url": item['versions'][0]['icon'],
-                        "dl_url": item['versions'][0]['download_url'],
-                        "last_update": item['date_updated'],
-                        "total_dl": downloads,
-                        "description": item['versions'][0]['description']
-                    }
-            
-            # Sort mods by most downloaded by default until we get better sorting later        
-            sorted_mods_by_dl = dict(sorted(mods.items(), key=lambda item: item[1]['total_dl'], reverse=True))
-            
-            pages = list(sorted_mods_by_dl.keys())
-            current_page = 0
-            
-            def get_mod_embed():
-                key = pages[current_page]
-                mod = sorted_mods_by_dl[key]
-                mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownloads: {mod['total_dl']}\n{mod['dl_url']}"
-                embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
-                embed = discord.Embed(
-                    title=embed_title,
-                    description=mod_embed_desc
-                )
-                embed.set_thumbnail(url=mod['icon_url'])
-                return embed
-            
-            message = await ctx.send(embed=get_mod_embed())
-            reactions = ['⏮️', '◀️', '▶️', '⏭️']
-            for reaction in reactions:
-                await message.add_reaction(reaction)
-                sleep(0.100) # Sleep for 100ms to hopefully avoid reactions getting placed out-of-order
+                reaction, _ = await self.bot.wait_for('reaction_add', timeout=60.0, check=check_react)
                 
-            def check_react(reaction, user):
-                return user == ctx.author and str(reaction.emoji) in reactions
-            
-            while True:
-                should_search = False
-                try:
-                    reaction, _ = await self.bot.wait_for('reaction_add', timeout=60.0, check=check_react)
-                    
-                    if str(reaction.emoji) == '⏮️':
-                        current_page = 0
-                    elif str(reaction.emoji) == '◀️':
-                        current_page = (current_page - 1) % len(pages)
-                    elif str(reaction.emoji) == '▶️':
-                        current_page = (current_page + 1) % len(pages)
-                    elif str(reaction.emoji) == '⏭️':
-                        current_page = len(pages) - 1
-                    
-                    await message.edit(embed=get_mod_embed())
-                    await message.remove_reaction(reaction, ctx.author)
-                    
-                except asyncio.TimeoutError:
-                    break
+                if str(reaction.emoji) == '⏮️':
+                    current_page = 0
+                elif str(reaction.emoji) == '◀️':
+                    current_page = (current_page - 1) % len(pages)
+                elif str(reaction.emoji) == '▶️':
+                    current_page = (current_page + 1) % len(pages)
+                elif str(reaction.emoji) == '⏭️':
+                    current_page = len(pages) - 1
                 
-            await message.clear_reactions()
-            should_search = True
-            return
-        else:
-            await ctx.send("Please wait for previous search to timeout")
-            return
+                await message.edit(embed=get_mod_embed())
+                await message.remove_reaction(reaction, ctx.author)
+                
+            except asyncio.TimeoutError:
+                break
+            
+        await message.clear_reactions()
+        active_search = False
+        return
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(ModSearch(bot))

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -1,7 +1,7 @@
 from discord.ext import commands
 import requests, re
-import discord
-import asyncio
+import discord, asyncio
+from time import sleep
 
 class ModSearch(commands.Cog):
     def __init__(self, bot :commands.Bot) -> None:
@@ -57,6 +57,7 @@ class ModSearch(commands.Cog):
         reactions = ['⏮️', '◀️', '▶️', '⏭️']
         for reaction in reactions:
             await message.add_reaction(reaction)
+            sleep(0.100) # Sleep for 100ms to hopefully avoid reactions getting placed out-of-order
             
         def check_react(reaction, user):
             return user == ctx.author and str(reaction.emoji) in reactions

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -61,7 +61,7 @@ class ModSearch(commands.Cog):
         def get_mod_embed():
             key = pages[current_page]
             mod = sorted_mods_by_dl[key]
-            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']} (YY/MM/DD)\nDownloads: {mod['total_dl']}\n{mod['ts_url']}"
+            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast updated on {mod['last_update']} (YY/MM/DD)\n{mod['total_dl']} Downloads\n{mod['ts_url']}"
             embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
             embed = discord.Embed(
                 title=embed_title,

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -61,7 +61,7 @@ class ModSearch(commands.Cog):
         def get_mod_embed():
             key = pages[current_page]
             mod = sorted_mods_by_dl[key]
-            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownloads: {mod['total_dl']}\n{mod['ts_url']}"
+            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']} (YY/MM/DD)\nDownloads: {mod['total_dl']}\n{mod['ts_url']}"
             embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
             embed = discord.Embed(
                 title=embed_title,

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -95,8 +95,10 @@ class ModSearch(commands.Cog):
                 elif str(reaction.emoji) == '⏭️':
                     current_page = len(pages) - 1
                 elif str(reaction.emoji) == '❌':
+                    active_search = False
                     await message.delete()
-                    raise asyncio.TimeoutError("Search cancelled")
+                    await message.send("Search cancelled")
+                    return
                 
                 await message.edit(embed=get_mod_embed())
                 await message.remove_reaction(reaction, ctx.author)

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -7,6 +7,8 @@ class ModSearch(commands.Cog):
     def __init__(self, bot :commands.Bot) -> None:
         self.bot = bot
         
+    active_search = False
+        
     @commands.hybrid_command(description="Search Northstar Thunderstore for mods")
     async def searchts(self, ctx, search_string: str):
         if active_search:

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -45,8 +45,9 @@ class ModSearch(commands.Cog):
             key = pages[current_page]
             mod = sorted_mods_by_dl[key]
             mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownloads: {mod['total_dl']}\n{mod['dl_url']}"
+            embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
             embed = discord.Embed(
-                title=mod["name"],
+                title=embed_title,
                 description=mod_embed_desc
             )
             return embed

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -61,7 +61,7 @@ class ModSearch(commands.Cog):
         def get_mod_embed():
             key = pages[current_page]
             mod = sorted_mods_by_dl[key]
-            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']} (YY/MM/DD)\nDownloads: {mod['total_dl']}\n{mod['ts_url']}"
+            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\n\nLast updated on {mod['last_update']} (YY/MM/DD)\n{mod['total_dl']}\n{mod['ts_url']} Downloads"
             embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
             embed = discord.Embed(
                 title=embed_title,

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -44,7 +44,7 @@ class ModSearch(commands.Cog):
         def get_mod_embed():
             key = pages[current_page]
             mod = sorted_mods_by_dl[key]
-            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownload: {mod['total_dl']}\n{mod['dl_url']}"
+            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownloads: {mod['total_dl']}\n{mod['dl_url']}"
             embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
             embed = discord.Embed(
                 title=embed_title,

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -29,6 +29,7 @@ class ModSearch(commands.Cog):
                 )
                 embed.set_thumbnail(url=mod['versions'][0]['icon'])
                 await ctx.send(embed=embed)
+                match_count = match_count + 1
         
 
 async def setup(bot: commands.Bot) -> None:

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -50,6 +50,7 @@ class ModSearch(commands.Cog):
                 title=embed_title,
                 description=mod_embed_desc
             )
+            embed.set_thumbnail(url=mod['icon_url'])
             return embed
         
         message = await ctx.send(embed=get_mod_embed())

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -14,6 +14,10 @@ class ModSearch(commands.Cog):
         
         global active_search
         
+        if len(search_string) < 3:
+            await ctx.send("Search must be at least 3 characters")
+            return
+        
         if active_search:
             await ctx.send("Please wait for the active search to timeout")
             return

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -20,7 +20,7 @@ class ModSearch(commands.Cog):
         
         mods = {}
         for i, item in enumerate(data):
-            match = re.search(search_string, mod["name"], re.IGNORECASE)
+            match = re.search(search_string, item["name"], re.IGNORECASE)
             if match:
                 downloads = 0
                 for version in item['versions']:

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -44,7 +44,7 @@ class ModSearch(commands.Cog):
         def get_mod_embed():
             key = pages[current_page]
             mod = sorted_mods_by_dl[key]
-            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownloads: {mod['total_dl']}\n{mod['dl_url']}"
+            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownload: {mod['total_dl']}\n{mod['dl_url']}"
             embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
             embed = discord.Embed(
                 title=embed_title,

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -7,7 +7,7 @@ class ModSearch(commands.Cog):
     def __init__(self, bot :commands.Bot) -> None:
         self.bot = bot
         
-    @commands.hybrid_command(description="Check Northstar master server status")
+    @commands.hybrid_command(description="Search Northstar Thunderstore for mods")
     async def searchts(self, ctx, search_string: str):
         try:
             response = requests.get("https://northstar.thunderstore.io/api/v1/package/")

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -69,7 +69,7 @@ class ModSearch(commands.Cog):
         reactions = ['⏮️', '◀️', '▶️', '⏭️']
         for reaction in reactions:
             await message.add_reaction(reaction)
-            sleep(0.100) # Sleep for 100ms to hopefully avoid reactions getting placed out-of-order
+            sleep(0.050) # Sleep for 100ms to hopefully avoid reactions getting placed out-of-order
             
         def check_react(reaction, user):
             return user == ctx.author and str(reaction.emoji) in reactions

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -61,7 +61,7 @@ class ModSearch(commands.Cog):
         def get_mod_embed():
             key = pages[current_page]
             mod = sorted_mods_by_dl[key]
-            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\n\nLast updated on {mod['last_update']} (YY/MM/DD)\n{mod['total_dl']}\n{mod['ts_url']} Downloads"
+            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']} (YY/MM/DD)\nDownloads: {mod['total_dl']}\n{mod['ts_url']}"
             embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
             embed = discord.Embed(
                 title=embed_title,

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -47,6 +47,10 @@ class ModSearch(commands.Cog):
                     "total_dl": downloads,
                     "description": item['versions'][0]['description']
                 }
+                
+        if not mods:
+            await ctx.send("No mods found")
+            return
         
         # Sort mods by most downloaded by default until we get better sorting later        
         sorted_mods_by_dl = dict(sorted(mods.items(), key=lambda item: item[1]['total_dl'], reverse=True))

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -42,7 +42,7 @@ class ModSearch(commands.Cog):
                     "name": item['name'].replace("_", " "),
                     "owner": item['owner'],
                     "icon_url": item['versions'][0]['icon'],
-                    "dl_url": item['versions'][0]['download_url'],
+                    "ts_url": item['package_url'],
                     "last_update": item['date_updated'][:(item['date_updated'].index('T'))], # Remove time from date string
                     "total_dl": downloads,
                     "description": item['versions'][0]['description']
@@ -61,7 +61,7 @@ class ModSearch(commands.Cog):
         def get_mod_embed():
             key = pages[current_page]
             mod = sorted_mods_by_dl[key]
-            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownloads: {mod['total_dl']}\n{mod['dl_url']}"
+            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast Updated: {mod['last_update']}\nDownloads: {mod['total_dl']}\n{mod['ts_url']}"
             embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
             embed = discord.Embed(
                 title=embed_title,

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -74,7 +74,7 @@ class ModSearch(commands.Cog):
         
         active_search = True
         
-        reactions = ['⏮️', '◀️', '▶️', '⏭️']
+        reactions = ['⏮️', '◀️', '▶️', '⏭️', '❌']
         for reaction in reactions:
             await message.add_reaction(reaction)
             sleep(0.050) # Sleep for 100ms to hopefully avoid reactions getting placed out-of-order
@@ -94,6 +94,9 @@ class ModSearch(commands.Cog):
                     current_page = (current_page + 1) % len(pages)
                 elif str(reaction.emoji) == '⏭️':
                     current_page = len(pages) - 1
+                elif str(reaction.emoji) == '❌':
+                    await message.delete()
+                    raise asyncio.TimeoutError("Search cancelled")
                 
                 await message.edit(embed=get_mod_embed())
                 await message.remove_reaction(reaction, ctx.author)

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -1,0 +1,35 @@
+from discord.ext import commands
+import requests, re
+import discord
+
+
+class ModSearch(commands.Cog):
+    def __init__(self, bot :commands.Bot) -> None:
+        self.bot = bot
+        
+    @commands.hybrid_command(description="Check Northstar master server status")
+    async def searchts(self, ctx, search_string: str):
+        try:
+            response = requests.get("https://northstar.thunderstore.io/api/v1/package/")
+            if response.status_code == 200:
+                data = response.json()
+        
+        except requests.exceptions.RequestException as err:
+            print(err)
+            return
+           
+        match_count = 0
+        for mod in data:
+            match = re.search(search_string, mod["name"], re.IGNORECASE)
+            if match and match_count < 3:
+                mod_desc = f"By {mod['owner']}\n{mod['versions'][0]['description']}\n{mod['versions'][0]['download_url']}"
+                embed = discord.Embed(
+                    title=mod["name"],
+                    description=mod_desc
+                )
+                embed.set_thumbnail(url=mod['versions'][0]['icon'])
+                await ctx.send(embed=embed)
+        
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ModSearch(bot))

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -61,7 +61,7 @@ class ModSearch(commands.Cog):
         def get_mod_embed():
             key = pages[current_page]
             mod = sorted_mods_by_dl[key]
-            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\nLast updated on {mod['last_update']} (YY/MM/DD)\n{mod['total_dl']} Downloads\n{mod['ts_url']}"
+            mod_embed_desc = f"By {mod['owner']}\n{mod['description']}\n\nLast updated on {mod['last_update']} (YY/MM/DD)\n{mod['total_dl']} Downloads\n{mod['ts_url']}"
             embed_title = f"{mod['name']} ({current_page + 1}/{len(pages)})"
             embed = discord.Embed(
                 title=embed_title,

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -97,7 +97,7 @@ class ModSearch(commands.Cog):
                 elif str(reaction.emoji) == '❌':
                     active_search = False
                     await message.delete()
-                    await message.send("Search cancelled")
+                    await ctx.send("Search cancelled")
                     return
                 
                 await message.edit(embed=get_mod_embed())

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -3,11 +3,11 @@ import requests, re
 import discord, asyncio
 from time import sleep
 
+active_search = False
+
 class ModSearch(commands.Cog):
     def __init__(self, bot :commands.Bot) -> None:
-        self.bot = bot
-        
-    active_search = False
+        self.bot = bot 
         
     @commands.hybrid_command(description="Search Northstar Thunderstore for mods")
     async def searchts(self, ctx, search_string: str):

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -71,7 +71,7 @@ class ModSearch(commands.Cog):
         
         while True:
             try:
-                reaction, _ = await self.bot.wait_for('reaction_add', timeout=60.0, check=check_react)
+                reaction, _ = await self.bot.wait_for('reaction_add', timeout=30.0, check=check_react)
                 
                 if str(reaction.emoji) == '⏮️':
                     current_page = 0

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -29,7 +29,7 @@ class ModSearch(commands.Cog):
                     for version in item['versions']:
                         downloads = downloads + version['downloads']
                     mods["result_" + str(i)] = {
-                        "name": item['name'],
+                        "name": item['name'].replace("_", " "),
                         "owner": item['owner'],
                         "icon_url": item['versions'][0]['icon'],
                         "dl_url": item['versions'][0]['download_url'],

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -11,6 +11,9 @@ class ModSearch(commands.Cog):
         
     @commands.hybrid_command(description="Search Northstar Thunderstore for mods")
     async def searchts(self, ctx, search_string: str):
+        
+        global active_search
+        
         if active_search:
             await ctx.send("Please wait for the active search to timeout")
             return


### PR DESCRIPTION
Implements `searchts` command. Accesses the Thunderstore API and searches for mods based on the string the user enters with the command. Stores relevant result information in it's own dictionary which is then sorted by most downloads in descending order. One mod result shown per page.