### PR TITLE
Omit mods tagged as nsfw from search results

### DIFF
--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -69,6 +69,8 @@ class ModSearch(commands.Cog):
         for i, item in enumerate(data):
             match = re.search(search_string, item["name"], re.IGNORECASE)
             if match:
+                if item['has_nsfw_content']: # Prevent mods labelled as containing NSFW content from appearing in searches
+                    continue
                 downloads = 0
                 for version in item['versions']:
                     downloads = downloads + version['downloads']


### PR DESCRIPTION
Note: the functionality of this solely relies on mod creators tagging their content as nsfw.