### PR TITLE
Change playtester ping msg to multi-line-string

### DIFF
--- a/cogs/PlaytesterPing.py
+++ b/cogs/PlaytesterPing.py
@@ -91,7 +91,13 @@ class PlayTesterPing(commands.Cog):
 
                 embed.set_author(name="Northstar " + rcVersion, icon_url="https://avatars.githubusercontent.com/u/86304187")
                 
-                pingMessage = await playtestPingChannel.send(f"<@&936669179359141908>, there is a new Northstar release candidate, `{rcVersion}`. If you find any issues or have feedback, please inform us in the thread attached to this message.\n\n**Installation**:\nGo to settings in FlightCore, and enable testing release channels (you only need to do this once). After you've done that, go to the play tab, click the arrow next to `LAUNCH GAME`, and select `Northstar release candidate`. Then, click the `UPDATE` button.", embed=embed)
+                pingMessage = await playtestPingChannel.send(
+                    f"""<@&936669179359141908>, there is a new Northstar release candidate, `{rcVersion}`. If you find any issues or have feedback, please inform us in the thread attached to this message.
+
+**Installation**:
+Go to settings in FlightCore, and enable testing release channels (you only need to do this once). After you've done that, go to the play tab, click the arrow next to `LAUNCH GAME`, and select `Northstar release candidate`. Then, click the `UPDATE` button.""",
+                    embed=embed
+                )
                 await pingMessage.create_thread(name=rcVersion)
 
 async def setup(bot: commands.Bot) -> None:


### PR DESCRIPTION
Makes it slightly nicer to read I guess. Except for the indentation part but that's kinda unavoidable with Python multiline strings .-.

Tested a bit with just running the relevant line in interactive Python. Did NOT test running the whole bot.