### PR TITLE
[RFC] style: Format project with black

### DIFF
--- a/Spectre.py
+++ b/Spectre.py
@@ -4,7 +4,21 @@ import util.JsonHandler
 from discord.ext import commands
 from dotenv import load_dotenv
 
-COGS = ("cogs.AutoResponse", "cogs.GlobalReplies", "cogs.UserReplies", "cogs.InstallChannelEmbed", "cogs.AllowedChannels", "cogs.LogReading", "cogs.PriceCheck", "cogs.AllowedUsers", "cogs.HelpCommand", "cogs.MasterCheck", "cogs.ModSearch", "cogs.ImageResponse", "cogs.PlaytesterPing")
+COGS = (
+    "cogs.AutoResponse",
+    "cogs.GlobalReplies",
+    "cogs.UserReplies",
+    "cogs.InstallChannelEmbed",
+    "cogs.AllowedChannels",
+    "cogs.LogReading",
+    "cogs.PriceCheck",
+    "cogs.AllowedUsers",
+    "cogs.HelpCommand",
+    "cogs.MasterCheck",
+    "cogs.ModSearch",
+    "cogs.ImageResponse",
+    "cogs.PlaytesterPing",
+)
 INTENTS = discord.Intents.default()
 INTENTS.message_content = True
 
@@ -14,7 +28,7 @@ allowed_users = util.JsonHandler.load_allowed_users()
 # Config docs
 # {
 #     "admin": <admin id>,
-#     "cooldowntime": <cooldown seconds>, 
+#     "cooldowntime": <cooldown seconds>,
 #     "noreplylist": <name of list.json>,
 #     "neverreplylist": <name of neverreplylist.json>
 #     "allowedchannels": <name of list.json>
@@ -22,12 +36,11 @@ allowed_users = util.JsonHandler.load_allowed_users()
 # }
 
 bot = commands.Bot(
-    intents=INTENTS,
-    command_prefix=config["prefix"],
-    owner_id=config["admin"]
+    intents=INTENTS, command_prefix=config["prefix"], owner_id=config["admin"]
 )
 
 bot.remove_command("help")
+
 
 class aclient(discord.Client):
     def __init__(self):
@@ -36,49 +49,56 @@ class aclient(discord.Client):
     async def on_ready(self):
         await self.wait_until_ready()
 
+
 @bot.event
 async def setup_hook() -> None:
     for cog in COGS:
         await bot.load_extension(cog)
 
+
 client = aclient()
 
-# Slash command to update commands
-@bot.hybrid_command(name='sync', description='Syncs the bot\'s commands. Allowed users only.')
-async def sync(ctx):
 
+# Slash command to update commands
+@bot.hybrid_command(
+    name="sync", description="Syncs the bot's commands. Allowed users only."
+)
+async def sync(ctx):
     if str(ctx.author.id) in allowed_users or ctx.author.id == bot.owner_id:
         await bot.tree.sync()
-        print('Commands synced successfully!')
-        await ctx.send('Commands synced successfully!')
+        print("Commands synced successfully!")
+        await ctx.send("Commands synced successfully!")
     else:
         await ctx.send("You don't have permission to use this command!", ephemeral=True)
 
 
-
 # Slash command to reload cogs
-@bot.hybrid_command(name='reload', description='Reloads the bot\'s cogs. Allowed users only.')
+@bot.hybrid_command(
+    name="reload", description="Reloads the bot's cogs. Allowed users only."
+)
 async def reload(ctx):
-
     if str(ctx.author.id) in allowed_users:
         for cog in COGS:
             await bot.reload_extension(cog)
-        print('Reloaded cogs successfully!')
+        print("Reloaded cogs successfully!")
         await ctx.send("Reloaded cogs succesfully!", ephemeral=True)
     else:
         await ctx.send("You don't have permission to use this command!", ephemeral=True)
 
 
-
 # Set the status for the bot
 @bot.hybrid_command(description="Set the status of the bot. Allowed users only.")
 async def setstatus(ctx, status: str):
-
     if str(ctx.author.id) in allowed_users:
-        await bot.change_presence(activity=discord.Activity(type=discord.ActivityType.listening, name=f"{status}"))
+        await bot.change_presence(
+            activity=discord.Activity(
+                type=discord.ActivityType.listening, name=f"{status}"
+            )
+        )
         await ctx.send(f"Set bot status to `Listening to {status}`!", ephemeral=True)
     else:
         await ctx.send("You don't have permission to use this command!", ephemeral=True)
+
 
 load_dotenv()
 util.JsonHandler.init_json()

--- a/cogs/AllowedChannels.py
+++ b/cogs/AllowedChannels.py
@@ -3,10 +3,12 @@ from discord.ext import commands
 
 
 class AllowedChannels(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        
-    @commands.hybrid_command(description="Enables automatic replies for the current channel. Allowed users only.")
+
+    @commands.hybrid_command(
+        description="Enables automatic replies for the current channel. Allowed users only."
+    )
     async def togglechannel(self, ctx):
         allowed_users = util.JsonHandler.load_allowed_users()
         data = util.JsonHandler.load_channels()
@@ -14,16 +16,23 @@ class AllowedChannels(commands.Cog):
         if str(ctx.author.id) in allowed_users:
             if str(ctx.channel.id) in data:
                 del data[str(ctx.channel.id)]
-                
-                await ctx.send("Successfully disabled automatic replies in this channel!")
+
+                await ctx.send(
+                    "Successfully disabled automatic replies in this channel!"
+                )
             else:
                 data[str(ctx.channel.id)] = f"{ctx.guild.name} - {ctx.channel.name}"
-                
-                await ctx.send("Successfully enabled automatic replies in this channel!")
+
+                await ctx.send(
+                    "Successfully enabled automatic replies in this channel!"
+                )
 
             util.JsonHandler.save_channels(data)
         else:
-            await ctx.send("You don't have permission to use this command", ephemeral=True)
+            await ctx.send(
+                "You don't have permission to use this command", ephemeral=True
+            )
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(AllowedChannels(bot))

--- a/cogs/AllowedUsers.py
+++ b/cogs/AllowedUsers.py
@@ -6,43 +6,67 @@ import discord
 
 allowed_users = util.JsonHandler.load_allowed_users()
 
+
 class AllowedUsers(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
-    @commands.hybrid_command(description="Removes a user from the allowed users list. Owner only.")
-    @app_commands.describe(user = "Toggle `user`'s ability to use specific bot commands")
-    async def toggleusercommands(self, ctx, user: typing.Optional[discord.Member], role: typing.Optional[discord.Role]):
-    
+    @commands.hybrid_command(
+        description="Removes a user from the allowed users list. Owner only."
+    )
+    @app_commands.describe(user="Toggle `user`'s ability to use specific bot commands")
+    async def toggleusercommands(
+        self,
+        ctx,
+        user: typing.Optional[discord.Member],
+        role: typing.Optional[discord.Role],
+    ):
         if ctx.author.id == self.bot.owner_id:
-
             if user is not None and Role is not None:
-                await ctx.send("Please only select either a user or a role to allow!", ephemeral=True)
+                await ctx.send(
+                    "Please only select either a user or a role to allow!",
+                    ephemeral=True,
+                )
 
             if user is not None:
                 if str(user.id) in allowed_users:
                     del allowed_users[str(user.id)]
-                    await ctx.send(f"Successfully removed {user.name}'s ability to use bot commands!", ephemeral=True)
-                
+                    await ctx.send(
+                        f"Successfully removed {user.name}'s ability to use bot commands!",
+                        ephemeral=True,
+                    )
+
                 else:
                     allowed_users[str(user.id)] = user.display_name
-                    await ctx.send(f"Successfully allowed {user.name} to use bot commands!", ephemeral=True)
-                
+                    await ctx.send(
+                        f"Successfully allowed {user.name} to use bot commands!",
+                        ephemeral=True,
+                    )
+
             if role is not None:
                 if str(role.id) in allowed_users:
                     del allowed_users[str(role.id)]
-                    await ctx.send(f"Succesfully remove {role.name}'s ability to use bot commands")
+                    await ctx.send(
+                        f"Succesfully remove {role.name}'s ability to use bot commands"
+                    )
 
                 else:
                     allowed_users[str(role.id)] = role.name
-                    await ctx.send(f"Successfully allowed {role.name} to use bot commands")
-                
+                    await ctx.send(
+                        f"Successfully allowed {role.name} to use bot commands"
+                    )
+
             else:
-                await ctx.send("Please select either a user or a role to allow!", ephemeral=True)
-                util.JsonHandler.save_allowed_users(allowed_users) 
+                await ctx.send(
+                    "Please select either a user or a role to allow!", ephemeral=True
+                )
+                util.JsonHandler.save_allowed_users(allowed_users)
 
         else:
-            await ctx.send("You don't have permission to use this command!", ephemeral=True)
+            await ctx.send(
+                "You don't have permission to use this command!", ephemeral=True
+            )
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(AllowedUsers(bot))

--- a/cogs/AutoResponse.py
+++ b/cogs/AutoResponse.py
@@ -6,20 +6,36 @@ from cogs.GlobalReplies import replycheck
 import re
 import asyncio
 
-responseEmbed = discord.Embed(title="Automatic bot response", description="", color=0x5D3FD3)
+responseEmbed = discord.Embed(
+    title="Automatic bot response", description="", color=0x5D3FD3
+)
 
 # Embed for automatically replying to potential questions about installing mods for Northstar
-installmods = discord.Embed(description="I noticed that you may have asked for help installing mods. You can do this automatically or manually.", color=0x5D3FD3)
-installmods.add_field(name="Automatic mod installation", value="Simply use a mod manager and navigate to the mods browser to automatically find and install mods.")
-installmods.add_field(name="Manual mod installation", value="See the image sent below for help installing mods manually. If it's hard to read, click into it, and hit `Open in browser`, then follow the image guide.")
+installmods = discord.Embed(
+    description="I noticed that you may have asked for help installing mods. You can do this automatically or manually.",
+    color=0x5D3FD3,
+)
+installmods.add_field(
+    name="Automatic mod installation",
+    value="Simply use a mod manager and navigate to the mods browser to automatically find and install mods.",
+)
+installmods.add_field(
+    name="Manual mod installation",
+    value="See the image sent below for help installing mods manually. If it's hard to read, click into it, and hit `Open in browser`, then follow the image guide.",
+)
 
 # Embed for automatically replying to potential mentions of "Authentication Failed", meant to be enabled when the Master Server Northstar is run on is down
-msdownembed = discord.Embed(title="I noticed you may have mentioned the error \"Authentication Failed\".", description="Currently, the master server Northstar's server browser operates on is down. This means that currently you can't connect and aren't alone in having the error. Please wait for the master server to come back up and continue to check [the annoucements channel](https://discord.com/channels/920776187884732556/920780605132800080) for more updates.\n\nIf I'm being accidentally triggered or annoying, please disable replies with the button below or ping @cooldudepugs", color=0x5D3FD3)
+msdownembed = discord.Embed(
+    title='I noticed you may have mentioned the error "Authentication Failed".',
+    description="Currently, the master server Northstar's server browser operates on is down. This means that currently you can't connect and aren't alone in having the error. Please wait for the master server to come back up and continue to check [the annoucements channel](https://discord.com/channels/920776187884732556/920780605132800080) for more updates.\n\nIf I'm being accidentally triggered or annoying, please disable replies with the button below or ping @cooldudepugs",
+    color=0x5D3FD3,
+)
 
 config = util.JsonHandler.load_json("config.json")
-        
+
+
 class AutoResponse(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         self.last_time = datetime.datetime.utcfromtimestamp(0)
         self.last_channel = 0
@@ -31,72 +47,110 @@ class AutoResponse(commands.Cog):
         enabledchannels = util.JsonHandler.load_channels()
         time_diff = (datetime.datetime.utcnow() - self.last_time).total_seconds()
 
-        if not (time_diff > config["cooldowntime"] or message.channel.id != self.last_channel):
-            self.last_channel = message.channel.id            
+        if not (
+            time_diff > config["cooldowntime"]
+            or message.channel.id != self.last_channel
+        ):
+            self.last_channel = message.channel.id
             print(f"Tried to send message while on cooldown! Didn't send message!")
             return
         else:
             if replycheck() == True:
                 if str(message.author.id) in users:
-                        return
-                    
+                    return
+
                 if str(message.author.id) in neverusers:
+                    return
+
+                if str(message.channel.id) in enabledchannels or str(
+                    message.channel.name
+                ).startswith("ticket"):
+                    # Should stop all bot messages
+                    if message.author.bot:
                         return
-                
-                if str(message.channel.id) in enabledchannels or str(message.channel.name).startswith("ticket"):
-                        # Should stop all bot messages
-                        if message.author.bot:
+
+                    elif re.search("player.*account", message.content.lower()):
+                        responseEmbed.add_field(
+                            name="Couldn't find player account error",
+                            value="Please read the [wiki section for this issue](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#playeraccount) to solve the error.",
+                        )
+
+                    elif re.search("Failed.creating.log.file", message.content.lower()):
+                        responseEmbed.add_field(
+                            name="Default EA path issues",
+                            value="If you have the game installed on EA, please follow the [wiki section](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#cannot-write-log-file-when-using-northstar-on-ea-app) for solving this issue.",
+                        )
+
+                    elif re.search(
+                        "controller.not.working", message.content.lower()
+                    ) or re.search(
+                        "can.i.use.controller.*northstar", message.content.lower()
+                    ):
+                        responseEmbed.add_field(
+                            name="Controller not working",
+                            value="Try following the [controller not working](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#controller) wiki section for multiple ways you can fix a controller not working on Northstar.",
+                        )
+
+                    elif re.search(
+                        "authentication.*failed", message.content.lower()
+                    ) or re.search("cant.*join", message.content.lower()):
+                        if util.MasterStatus.IsMasterDown() == True:
+                            await message.channel.send(
+                                reference=message, embed=msdownembed
+                            )
+                        else:
                             return
 
-                        elif re.search("player.*account", message.content.lower()):
-                            responseEmbed.add_field(name="Couldn't find player account error", value="Please read the [wiki section for this issue](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#playeraccount) to solve the error.")
+                    elif re.search("how|help", message.content.lower()) and re.search(
+                        "install.northstar", message.content.lower()
+                    ):
+                        if re.search("uninstall", message.content.lower()):
+                            responseEmbed.add_field(
+                                name="Uninstalling Northstar",
+                                value="Note that if you're wanting to play vanilla, you can simply launch the vanilla game on Steam (remove the `-northstar` launch arg if you added it).\n\nIf you still want to delete Northstar however, deleting `NorthstarLauncher.exe`, `Northstar.dll`, and the `R2Northstar` folder from the `titanfall2` directory should be enough.\n\nIf you want to clear absolutely everything, you can also delete `r2ds.bat` and `LEGAL.txt` from the `titanfall2` directory, and delete the `bin` folder in the `titanfall2 directory`, then verify the game's files to restore the vanilla files found in the bin folder.",
+                            )
+                        else:
+                            responseEmbed.add_field(
+                                name="Installing Northstar",
+                                value="Please read the [installation channel](https://discordapp.com/channels/920776187884732556/922662496588943430) for ways to install Northstar.",
+                            )
 
-                        elif re.search("Failed.creating.log.file", message.content.lower()):
-                            responseEmbed.add_field(name="Default EA path issues", value="If you have the game installed on EA, please follow the [wiki section](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#cannot-write-log-file-when-using-northstar-on-ea-app) for solving this issue.")
+                    # note: rewrite this later
+                    elif (
+                        re.search("help|how", message.content.lower())
+                        and re.search("titanfall|northstar", message.content.lower())
+                        and re.search("install.*mods", message.content.lower())
+                    ):
+                        await message.channel.send(reference=message, embed=installmods)
+                        await message.channel.send(
+                            "https://cdn.discordapp.com/attachments/942391932137668618/1069362595192127578/instruction_bruh.png"
+                        )
+                        print(f"Northstar mods installing embed reply sent")
 
-                        elif re.search("controller.not.working", message.content.lower()) or re.search("can.i.use.controller.*northstar", message.content.lower()):
-                            responseEmbed.add_field(name="Controller not working", value="Try following the [controller not working](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#controller) wiki section for multiple ways you can fix a controller not working on Northstar.")
-                            
-                        elif re.search("authentication.*failed", message.content.lower()) or re.search("cant.*join", message.content.lower()):
-                            if util.MasterStatus.IsMasterDown() == True:
-                                await message.channel.send(reference=message, embed=msdownembed)
-                            else:
-                                return
-
-                        elif re.search("how|help", message.content.lower()) and re.search("install.northstar", message.content.lower()):
-                            if re.search("uninstall", message.content.lower()):
-                                responseEmbed.add_field(name="Uninstalling Northstar", value="Note that if you're wanting to play vanilla, you can simply launch the vanilla game on Steam (remove the `-northstar` launch arg if you added it).\n\nIf you still want to delete Northstar however, deleting `NorthstarLauncher.exe`, `Northstar.dll`, and the `R2Northstar` folder from the `titanfall2` directory should be enough.\n\nIf you want to clear absolutely everything, you can also delete `r2ds.bat` and `LEGAL.txt` from the `titanfall2` directory, and delete the `bin` folder in the `titanfall2 directory`, then verify the game's files to restore the vanilla files found in the bin folder.")
-                            else:
-                                responseEmbed.add_field(name="Installing Northstar", value="Please read the [installation channel](https://discordapp.com/channels/920776187884732556/922662496588943430) for ways to install Northstar.")
-                    
-                        # note: rewrite this later
-                        elif re.search("help|how", message.content.lower()) and re.search("titanfall|northstar", message.content.lower()) and re.search("install.*mods", message.content.lower()):
-                            await message.channel.send(reference=message, embed=installmods)
-                            await message.channel.send("https://cdn.discordapp.com/attachments/942391932137668618/1069362595192127578/instruction_bruh.png")
-                            print(f"Northstar mods installing embed reply sent")
-
-                        if len(responseEmbed.fields) > 0:
-                            await message.channel.typing()
-                            await asyncio.sleep(3)
-                            await message.channel.send(reference=message, embed=responseEmbed)
-                            responseEmbed.clear_fields()
+                    if len(responseEmbed.fields) > 0:
+                        await message.channel.typing()
+                        await asyncio.sleep(3)
+                        await message.channel.send(
+                            reference=message, embed=responseEmbed
+                        )
+                        responseEmbed.clear_fields()
 
                 if message.channel.id == 937922165163065384:
+                    # Note: this is actually really gross. discord's api doesn't like when you try to add multiple emojis at once (say, from a list)
+                    # and will instead place them in the incorrect order regardless of sleep time or order you place them in the list :P
 
-                        # Note: this is actually really gross. discord's api doesn't like when you try to add multiple emojis at once (say, from a list)
-                        # and will instead place them in the incorrect order regardless of sleep time or order you place them in the list :P
+                    await message.add_reaction("🔴")
+                    await asyncio.sleep(1)
 
-                        await message.add_reaction("🔴")
-                        await asyncio.sleep(1)
+                    await message.add_reaction("🟠")
+                    await asyncio.sleep(1)
 
-                        await message.add_reaction("🟠")
-                        await asyncio.sleep(1)
+                    await message.add_reaction("🟢")
+                    await asyncio.sleep(1)
 
-                        await message.add_reaction("🟢")
-                        await asyncio.sleep(1)
-                            
                 self.last_time = datetime.datetime.utcnow()
             self.last_channel = message.channel.id
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(AutoResponse(bot))

--- a/cogs/GlobalReplies.py
+++ b/cogs/GlobalReplies.py
@@ -6,39 +6,51 @@ from discord.ext import commands
 replies = True
 
 # Embeds about global enabling/denying automatic replies for the bot
-replieson = discord.Embed(title="Automatic bot replies set to ***ON***", color=0x287e29)
-repliesoff = discord.Embed(title="Automatic bot replies set to ***OFF***", color=0xDC143C)
+replieson = discord.Embed(title="Automatic bot replies set to ***ON***", color=0x287E29)
+repliesoff = discord.Embed(
+    title="Automatic bot replies set to ***OFF***", color=0xDC143C
+)
 
 # Embeds about the reply status of the bot
-replystatusenabled = discord.Embed(title="Automatic bot replies are currently enabled", color=0x6495ED)
-replystatusdisabled = discord.Embed(title="Automatic bot replies are currently disabled", color=0xDC143C)
+replystatusenabled = discord.Embed(
+    title="Automatic bot replies are currently enabled", color=0x6495ED
+)
+replystatusdisabled = discord.Embed(
+    title="Automatic bot replies are currently disabled", color=0xDC143C
+)
+
 
 def replycheck():
     return replies
 
+
 class GlobalReplies(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-    
+
     # Enables replies across all servers
-    @commands.hybrid_command(description="Globally enables Spectre replying to messages. Allowed users only.")
+    @commands.hybrid_command(
+        description="Globally enables Spectre replying to messages. Allowed users only."
+    )
     async def toggleglobalreplies(self, ctx):
         allowed_users = util.JsonHandler.load_allowed_users()
 
         if str(ctx.author.id) in allowed_users:
             global replies
-            
+
             if replies == False:
                 replies = True
                 await ctx.send(embed=replieson)
                 print(f"Automatic bot replies are enabled")
-                
+
             elif replies == True:
                 replies = False
                 await ctx.send(embed=repliesoff)
                 print(f"Automatic bot replies are disabled")
         else:
-            await ctx.send("You don't have permission to use this command!", ephemeral=True)
+            await ctx.send(
+                "You don't have permission to use this command!", ephemeral=True
+            )
 
     # Displays the current status of replies across all servers
     @commands.hybrid_command(description="Displays if bot replies are on or off")
@@ -49,23 +61,44 @@ class GlobalReplies(commands.Cog):
 
         if replies == True:
             if str(ctx.author.id) in neverusers:
-                replystatusenabled.add_field(name=f"{ctx.author.display_name}'s ability to control replies:", value="Disabled", inline=False)
+                replystatusenabled.add_field(
+                    name=f"{ctx.author.display_name}'s ability to control replies:",
+                    value="Disabled",
+                    inline=False,
+                )
             if str(ctx.author.id) in users:
-                replystatusenabled.add_field(name=f"{ctx.author.display_name}'s automatic replies:", value="Disabled", inline=False)
+                replystatusenabled.add_field(
+                    name=f"{ctx.author.display_name}'s automatic replies:",
+                    value="Disabled",
+                    inline=False,
+                )
             if str(ctx.channel.id) in allowedchannels:
-                replystatusenabled.add_field(name="Automatic replies in this channel:", value="Enabled")
+                replystatusenabled.add_field(
+                    name="Automatic replies in this channel:", value="Enabled"
+                )
             await ctx.send(embed=replystatusenabled, ephemeral=True)
             replystatusenabled.clear_fields()
-            
+
         elif replies == False:
             if str(ctx.author.id) in neverusers:
-                replystatusdisabled.add_field(name=f"{ctx.author.display_name}'s ability to control replies:", value="Disabled", inline=False)
+                replystatusdisabled.add_field(
+                    name=f"{ctx.author.display_name}'s ability to control replies:",
+                    value="Disabled",
+                    inline=False,
+                )
             if str(ctx.author.id) in users:
-                replystatusdisabled.add_field(name=f"{ctx.author.display_name}'s automatic replies:", value="Disabled", inline=False)
+                replystatusdisabled.add_field(
+                    name=f"{ctx.author.display_name}'s automatic replies:",
+                    value="Disabled",
+                    inline=False,
+                )
             if str(ctx.channel.id) in allowedchannels:
-                replystatusdisabled.add_field(name="Automatic replies in this channel:", value="Enabled")
+                replystatusdisabled.add_field(
+                    name="Automatic replies in this channel:", value="Enabled"
+                )
             await ctx.send(embed=replystatusdisabled, ephemeral=True)
             replystatusdisabled.clear_fields()
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(GlobalReplies(bot))

--- a/cogs/HelpCommand.py
+++ b/cogs/HelpCommand.py
@@ -1,18 +1,39 @@
 import discord
 from discord.ext import commands
 
+
 class helpCommand(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
     @commands.hybrid_command(description="Display information for using the bot")
     async def help(self, ctx):
-        helpembed = discord.Embed(title="Spectre", description="Spectre is a bot created by Cyn (aka cooldudepugs) with major help from H0L0. Its purpose is to try to automatically solve issues that users have.", color=0x6495ED)
+        helpembed = discord.Embed(
+            title="Spectre",
+            description="Spectre is a bot created by Cyn (aka cooldudepugs) with major help from H0L0. Its purpose is to try to automatically solve issues that users have.",
+            color=0x6495ED,
+        )
         helpembed.add_field(name="", value="\u200b")
-        helpembed.add_field(name="togglereplies", value="Toggles the bot replying to the person who used the command", inline=False)
-        helpembed.add_field(name="replystatus", value="Sends an embed about the status of replies for the user", inline=False)
-        helpembed.add_field(name="price", value="Shows the current price of Titanfall 2, and if it's on sale. Entering a region with a slash command allows you to search by region", inline=False)
-        helpembed.add_field(name="", value="You can view a full list of the commands on the [GitHub repo's wiki](https://github.com/itscynxx/Spectre/wiki)", inline=False)
+        helpembed.add_field(
+            name="togglereplies",
+            value="Toggles the bot replying to the person who used the command",
+            inline=False,
+        )
+        helpembed.add_field(
+            name="replystatus",
+            value="Sends an embed about the status of replies for the user",
+            inline=False,
+        )
+        helpembed.add_field(
+            name="price",
+            value="Shows the current price of Titanfall 2, and if it's on sale. Entering a region with a slash command allows you to search by region",
+            inline=False,
+        )
+        helpembed.add_field(
+            name="",
+            value="You can view a full list of the commands on the [GitHub repo's wiki](https://github.com/itscynxx/Spectre/wiki)",
+            inline=False,
+        )
         await ctx.send(embed=helpembed, ephemeral=True)
 
 

--- a/cogs/ImageResponse.py
+++ b/cogs/ImageResponse.py
@@ -6,65 +6,104 @@ import util.JsonHandler
 import os
 import discord
 
-imageReadEmbed = discord.Embed(title="Automatic Image Reading:", description="", color=0x5D3FD3)
+imageReadEmbed = discord.Embed(
+    title="Automatic Image Reading:", description="", color=0x5D3FD3
+)
+
 
 class imageStuff(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
-        self.bot = bot 
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
 
     @commands.Cog.listener()
     async def on_message(self, message):
-
         channels = util.JsonHandler.load_channels()
         users = util.JsonHandler.load_users()
 
         if str(message.author.id) in users:
             return
-        
+
         if str(message.channel.id) in channels:
             if message.attachments:
-
                 await message.attachments[0].save("image.png")
-                image = Image.open('image.png')
+                image = Image.open("image.png")
                 text = pytesseract.image_to_string(image)
 
                 if re.search("windows.protected.your.pc", text.lower()):
-                    imageReadEmbed.add_field(name="", value="Mod managers sometimes get auto flagged by Windows Defender because they don't have a digital signature, which Windows automatically (falsely) assumes is dangerous. These files, however, are not dangerous. They're all open source (so you can see all the code that make them up) if you want to confirm for yourself.\n\nYou can simply press `More Info` and `Run Anyway` to use the application. Please only do this when I respond if you're getting this message specifically for a Northstar mod manager, and nothing else.")
+                    imageReadEmbed.add_field(
+                        name="",
+                        value="Mod managers sometimes get auto flagged by Windows Defender because they don't have a digital signature, which Windows automatically (falsely) assumes is dangerous. These files, however, are not dangerous. They're all open source (so you can see all the code that make them up) if you want to confirm for yourself.\n\nYou can simply press `More Info` and `Run Anyway` to use the application. Please only do this when I respond if you're getting this message specifically for a Northstar mod manager, and nothing else.",
+                    )
 
-                if re.search("items.nut", text.lower()) and re.search("INVALID_REF", text.lower()):
-                    imageReadEmbed.add_field(name="", value="If you're encountering the \"INVALID_REF\" issue, please double check if you've removed any mods that do things like add skins to the game. A big cause of this is removing MoreSkins while a skin is equipped on a gun, making the game try to load something that doesn't exist. If you aren't sure or this didn't work, you'll have to reset multiplayer data, which should fix the issue. You can do this by opening the console on the main menu by hitting `~`, typing `ns_resetpersistence` , and then hitting enter.")
+                if re.search("items.nut", text.lower()) and re.search(
+                    "INVALID_REF", text.lower()
+                ):
+                    imageReadEmbed.add_field(
+                        name="",
+                        value="If you're encountering the \"INVALID_REF\" issue, please double check if you've removed any mods that do things like add skins to the game. A big cause of this is removing MoreSkins while a skin is equipped on a gun, making the game try to load something that doesn't exist. If you aren't sure or this didn't work, you'll have to reset multiplayer data, which should fix the issue. You can do this by opening the console on the main menu by hitting `~`, typing `ns_resetpersistence` , and then hitting enter.",
+                    )
 
-                if re.search("Encountered.CLIENT.script.compilation.error", text.lower()) and re.search("error|help", message.content.lower()):
-                    imageReadEmbed.add_field(name="", value="From this image alone, we can't see what's causing the issue. Please send a screenshot of the console (open it by hitting the `~` key), or send the newest log. You can find logs in `Titanfall2/R2Northstar/logs`, with the newest being on the bottom by default.")
+                if re.search(
+                    "Encountered.CLIENT.script.compilation.error", text.lower()
+                ) and re.search("error|help", message.content.lower()):
+                    imageReadEmbed.add_field(
+                        name="",
+                        value="From this image alone, we can't see what's causing the issue. Please send a screenshot of the console (open it by hitting the `~` key), or send the newest log. You can find logs in `Titanfall2/R2Northstar/logs`, with the newest being on the bottom by default.",
+                    )
 
-                if re.search("Invalid.or.expired.masterserver.token", text.lower()) or re.search("Couldn't.find.player.account", text.lower()):
-                    imageReadEmbed.add_field(name="", value="Try following the guide on solving the \"Couldn't find player account\" and \"Invalid master server token\" errors [here](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#playeraccount)")
+                if re.search(
+                    "Invalid.or.expired.masterserver.token", text.lower()
+                ) or re.search("Couldn't.find.player.account", text.lower()):
+                    imageReadEmbed.add_field(
+                        name="",
+                        value='Try following the guide on solving the "Couldn\'t find player account" and "Invalid master server token" errors [here](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#playeraccount)',
+                    )
 
                 if re.search("MSVCP120.dll", text.lower()):
-                    imageReadEmbed.add_field(name="", value="The \"MSVCP120.dll\" error comes up when you're missing a dependency Titanfall 2 uses to run. Follow the [wiki section for this issue](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#msvcr) to solve it.")
+                    imageReadEmbed.add_field(
+                        name="",
+                        value='The "MSVCP120.dll" error comes up when you\'re missing a dependency Titanfall 2 uses to run. Follow the [wiki section for this issue](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#msvcr) to solve it.',
+                    )
 
                 # FlightCore specific errors
                 if re.search("Mod.failed.sanity.check", text.lower()):
-                    imageReadEmbed.add_field(name="", value="The \"Mod failed sanity check\" error is specific to FlightCore, and means that the mod isn't properly formatted and FlightCore can't automatically install it. However, you can still follow the [manual mod install guide](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/manual-installation#installing-northstar-mods-manually) to install the mod you wanted.")
+                    imageReadEmbed.add_field(
+                        name="",
+                        value="The \"Mod failed sanity check\" error is specific to FlightCore, and means that the mod isn't properly formatted and FlightCore can't automatically install it. However, you can still follow the [manual mod install guide](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/manual-installation#installing-northstar-mods-manually) to install the mod you wanted.",
+                    )
 
                 # Viper specific errors
                 if re.search("Unknown.error*an.unknown.error.occurred", text.lower()):
-                    imageReadEmbed.add_field(name="", value="If you're using Viper, please click on the error message shown in this image and send a screenshot of the actual error message that pops up afterwards.")
+                    imageReadEmbed.add_field(
+                        name="",
+                        value="If you're using Viper, please click on the error message shown in this image and send a screenshot of the actual error message that pops up afterwards.",
+                    )
 
-                if re.search("operation.not.permitted", text.lower()) and re.search("EA.Games", text.lower()):
-                    imageReadEmbed.add_field(name="", value="EA's default install directory has some issues associated with it, which can be solved by following the [wiki section about this error](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#cannot-write-log-file-when-using-northstar-on-ea-app)")
+                if re.search("operation.not.permitted", text.lower()) and re.search(
+                    "EA.Games", text.lower()
+                ):
+                    imageReadEmbed.add_field(
+                        name="",
+                        value="EA's default install directory has some issues associated with it, which can be solved by following the [wiki section about this error](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting#cannot-write-log-file-when-using-northstar-on-ea-app)",
+                    )
 
                 if len(imageReadEmbed.fields) > 0:
                     if len(imageReadEmbed) > 1:
                         return
                     else:
-                        imageReadEmbed.add_field(name="", value="\nPlease note that I'm a bot automatically reading your image. There is a chance this information is wrong, in which case please ping @Cyn")
-                        await message.channel.send(embed=imageReadEmbed, reference=message)
+                        imageReadEmbed.add_field(
+                            name="",
+                            value="\nPlease note that I'm a bot automatically reading your image. There is a chance this information is wrong, in which case please ping @Cyn",
+                        )
+                        await message.channel.send(
+                            embed=imageReadEmbed, reference=message
+                        )
                         imageReadEmbed.clear_fields()
 
                 os.remove("image.png")
                 # is this bad? probably
                 # does it work? also probably
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(imageStuff(bot))

--- a/cogs/InstallChannelEmbed.py
+++ b/cogs/InstallChannelEmbed.py
@@ -5,26 +5,57 @@ from discord.ext import commands
 replies = True
 
 # Embeds for the installation channel - Help mention
-helpembed = discord.Embed(title="Having issues with Northstar?", color=0xfff9ac)
-helpembed.add_field(name="Troubleshooting issues with Northstar or installing Northstar", value="Check out the [FAQ](https://r2northstar.gitbook.io/r2northstar-wiki/faq) and [troubleshooting](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting) pages of the wiki for your error\n\nIf you can\'t find your error, feel free to open a ticket in the [help channel](https://discordapp.com/channels/920776187884732556/922663326994018366/1101924175343517827) by reading the embedded message and clicking the button to open a ticket")
+helpembed = discord.Embed(title="Having issues with Northstar?", color=0xFFF9AC)
+helpembed.add_field(
+    name="Troubleshooting issues with Northstar or installing Northstar",
+    value="Check out the [FAQ](https://r2northstar.gitbook.io/r2northstar-wiki/faq) and [troubleshooting](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/troubleshooting) pages of the wiki for your error\n\nIf you can't find your error, feel free to open a ticket in the [help channel](https://discordapp.com/channels/920776187884732556/922663326994018366/1101924175343517827) by reading the embedded message and clicking the button to open a ticket",
+)
 
 # Embeds for the installation channel - Manual
-manual = discord.Embed(title="Manual Installation", description="Note: Does not automatically update. You will have to do this every time Northstar has an update, and install mods and mod dependencies yourself\n", color=0xff6969)
-manual.add_field(name="\u200b", value="Download the newest `.zip` from the [releases page](https://github.com/R2Northstar/Northstar/releases/latest)\n\nFollow the [Manual installation guide](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/manual-installation)")
+manual = discord.Embed(
+    title="Manual Installation",
+    description="Note: Does not automatically update. You will have to do this every time Northstar has an update, and install mods and mod dependencies yourself\n",
+    color=0xFF6969,
+)
+manual.add_field(
+    name="\u200b",
+    value="Download the newest `.zip` from the [releases page](https://github.com/R2Northstar/Northstar/releases/latest)\n\nFollow the [Manual installation guide](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/manual-installation)",
+)
 
 # Embeds for the installation channel - Automatic
-installation = discord.Embed(title="Automatic Installation for Northstar (recommended)", description="Automatic updates and mod installation are also parts of mod managers", color=0x69ff69)
-installation.add_field(name="FlightCore", value="Simple, easy to use mod manager and Northstar installer. Most stable mod manager.\n\nWorks on Windows and Linux, and is actively updated.\n\n[Download (Windows)](https://r2northstartools.github.io/FlightCore/index.html?win-setup)\n\n[Guide to setting up FlightCore](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/northstar-installers/flightcore-guide)", inline=True)
-installation.add_field(name="VTOL", value="Advanced, feature rich mod manager and Northstar installer. Additionally very useful if you might want to make mods.\n\nWorks on Windows, and is actively updated.\n\n[Download (Windows)](https://github.com/BigSpice/VTOL/releases/latest/download/VTOL_Installer.msi)\n\n[Guide to setting up VTOL](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/northstar-installers/vtol-guide)", inline=True)
-installation.add_field(name="Viper", value="Simple, easy to use mod manager and Northstar installer. Good when it works.\n\nWorks on Windows and Linux, and occasionally recieves bug fix updates.\n\n[Download (Windows)](https://0negal.github.io/viper/index.html?win-setup)\n\n[Guide to setting up Viper](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/northstar-installers/viper-guide)", inline=True)
+installation = discord.Embed(
+    title="Automatic Installation for Northstar (recommended)",
+    description="Automatic updates and mod installation are also parts of mod managers",
+    color=0x69FF69,
+)
+installation.add_field(
+    name="FlightCore",
+    value="Simple, easy to use mod manager and Northstar installer. Most stable mod manager.\n\nWorks on Windows and Linux, and is actively updated.\n\n[Download (Windows)](https://r2northstartools.github.io/FlightCore/index.html?win-setup)\n\n[Guide to setting up FlightCore](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/northstar-installers/flightcore-guide)",
+    inline=True,
+)
+installation.add_field(
+    name="VTOL",
+    value="Advanced, feature rich mod manager and Northstar installer. Additionally very useful if you might want to make mods.\n\nWorks on Windows, and is actively updated.\n\n[Download (Windows)](https://github.com/BigSpice/VTOL/releases/latest/download/VTOL_Installer.msi)\n\n[Guide to setting up VTOL](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/northstar-installers/vtol-guide)",
+    inline=True,
+)
+installation.add_field(
+    name="Viper",
+    value="Simple, easy to use mod manager and Northstar installer. Good when it works.\n\nWorks on Windows and Linux, and occasionally recieves bug fix updates.\n\n[Download (Windows)](https://0negal.github.io/viper/index.html?win-setup)\n\n[Guide to setting up Viper](https://r2northstar.gitbook.io/r2northstar-wiki/installing-northstar/northstar-installers/viper-guide)",
+    inline=True,
+)
+
 
 class InstallationChannel(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
     # Slash command to send the embeds for the installation channel
-    @commands.hybrid_command(description="Information for the #installation channel. Allowed users only.")
-    async def installation(self, ctx): # Yes, this gives an "Interaction failed" error. This is intended. This is so only the embeds show and no "x person used slash command" text appears
+    @commands.hybrid_command(
+        description="Information for the #installation channel. Allowed users only."
+    )
+    async def installation(
+        self, ctx
+    ):  # Yes, this gives an "Interaction failed" error. This is intended. This is so only the embeds show and no "x person used slash command" text appears
         allowed_users = util.JsonHandler.load_allowed_users()
 
         if str(ctx.author.id) in allowed_users:
@@ -33,7 +64,10 @@ class InstallationChannel(commands.Cog):
             await ctx.channel.send(embed=installation)
 
         else:
-            await ctx.channel.send("You don't have permission to use this command!", ephemeral=True)
+            await ctx.channel.send(
+                "You don't have permission to use this command!", ephemeral=True
+            )
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(InstallationChannel(bot))

--- a/cogs/LogReading.py
+++ b/cogs/LogReading.py
@@ -7,9 +7,10 @@ import shutil
 import os
 import re
 
+
 def decodetext(text, text_to_filter, text_to_filter2):
-    filtered_bytes = text.replace(b'\x82', b'')
-    decoded_string = filtered_bytes.decode('utf-8')
+    filtered_bytes = text.replace(b"\x82", b"")
+    decoded_string = filtered_bytes.decode("utf-8")
     split_v2 = str(decoded_string)
     lines_split = split_v2.splitlines()
     new_text = ""
@@ -21,69 +22,92 @@ def decodetext(text, text_to_filter, text_to_filter2):
 
 def versionCheck():
     try:
-        gh_api_response = requests.get("https://api.github.com/repos/R2Northstar/Northstar/releases/latest")
+        gh_api_response = requests.get(
+            "https://api.github.com/repos/R2Northstar/Northstar/releases/latest"
+        )
         if gh_api_response.status_code == 200:
-                gh_data = gh_api_response.json()
+            gh_data = gh_api_response.json()
         else:
-            print(f"Error code when retrieving GitHub API: {gh_api_response.status_code}")
+            print(
+                f"Error code when retrieving GitHub API: {gh_api_response.status_code}"
+            )
     except requests.exceptions.RequestException as err:
         print(f"GitHub API request failed: {err}")
         return None
-    
-    ns_current_version = gh_data["name"][1:] # This gets the version as the raw version number without the "v". So '1.7.3' vs 'v1.7.3'
+
+    ns_current_version = gh_data["name"][
+        1:
+    ]  # This gets the version as the raw version number without the "v". So '1.7.3' vs 'v1.7.3'
     return ns_current_version
-   
+
+
 audioList = []
 modSplitList = []
 modsList = []
 modsListDisabled = []
 modsDisabledCore = []
 
-problem = discord.Embed(title="Problems I found in your log:", description="", color=0x5D3FD3)
+problem = discord.Embed(
+    title="Problems I found in your log:", description="", color=0x5D3FD3
+)
 dmLog = discord.Embed(title="Somebody sent a log!", description="", color=0x5D3FD3)
-oldLog = discord.Embed(title="It looks like the log you've sent is older! Please send the newest one.", description="Windows puts the newest logs at the bottom of the logs folder due to how they're named.", color=0x5D3FD3) 
+oldLog = discord.Embed(
+    title="It looks like the log you've sent is older! Please send the newest one.",
+    description="Windows puts the newest logs at the bottom of the logs folder due to how they're named.",
+    color=0x5D3FD3,
+)
 
-class LogButtons(discord.ui.View):    
 
+class LogButtons(discord.ui.View):
     # note: disabled mods still appear in enabled list. dunno why
     @discord.ui.button(label="List of enabled mods", style=discord.ButtonStyle.success)
-    async def modList(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def modList(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         modString = ""
         for mod in modsList:
             if mod + "\n" in modsListDisabled:
                 continue
             else:
                 modString = modString + "- " + mod
-        
-        await interaction.response.send_message(f"The user has the following mods enabled: \n{modString}", ephemeral=True)
+
+        await interaction.response.send_message(
+            f"The user has the following mods enabled: \n{modString}", ephemeral=True
+        )
 
     @discord.ui.button(label="List of disabled mods", style=discord.ButtonStyle.red)
-    async def modListDisabled(self, interaction: discord.Interaction, button: discord.ui.Button):
+    async def modListDisabled(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         modStringDisabled = ""
         for mod in modsListDisabled:
             modStringDisabled = modStringDisabled + "- " + mod
-        
-        await interaction.response.send_message(f"The user has the following mods disabled: \n{modStringDisabled}", ephemeral=True)
-        
+
+        await interaction.response.send_message(
+            f"The user has the following mods disabled: \n{modStringDisabled}",
+            ephemeral=True,
+        )
+
+
 class LogReading(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
     intents = discord.Intents.default()
     intents.messages = True
     intents.message_content = True
 
-            
     @commands.Cog.listener()
     async def on_guild_channel_create(self, channel):
         if str(channel.name).startswith("ticket"):
             await channel.typing()
             sleep(3)
-            await channel.send("I'm a bot automatically replying to the ticket being opened. If you're having an issue with the Northstar client itself, please send a log so that I can try to automatically read it, or a human can read it better. You can do this by going to `Titanfall2/R2Northstar/logs` and sending the newest `nslog` you have. Make sure not to send an `nsdmp`, and that you send the newest one! The newest ones are near the bottom by default on windows.\n\nIf I don't automatically respond, please wait for a human to assist. If you're getting an error MESSAGE in game, you could also try typing that out here, as I automatically reply to some of those as well.")
+            await channel.send(
+                "I'm a bot automatically replying to the ticket being opened. If you're having an issue with the Northstar client itself, please send a log so that I can try to automatically read it, or a human can read it better. You can do this by going to `Titanfall2/R2Northstar/logs` and sending the newest `nslog` you have. Make sure not to send an `nsdmp`, and that you send the newest one! The newest ones are near the bottom by default on windows.\n\nIf I don't automatically respond, please wait for a human to assist. If you're getting an error MESSAGE in game, you could also try typing that out here, as I automatically reply to some of those as well."
+            )
 
     @commands.Cog.listener()
     async def on_message(self, message):
-
         global hud
         global callback
         global compileErrorClientKillCallback
@@ -91,8 +115,8 @@ class LogReading(commands.Cog):
         global audioProblem
         global rgbError
         global frameworkError
-        global modsInstalled 
-        global crashCounter 
+        global modsInstalled
+        global crashCounter
         global betterServerBrowser
         global oldVersion
         global disabledCoreMod
@@ -115,53 +139,59 @@ class LogReading(commands.Cog):
         allowed_channels = util.JsonHandler.load_channels()
         if message.author.bot:
             return
-        
 
         else:
-            
-            if str(message.channel.id) in allowed_channels or str(message.channel.name).startswith("ticket"):
+            if str(message.channel.id) in allowed_channels or str(
+                message.channel.name
+            ).startswith("ticket"):
                 if message.attachments:
-                    filename = message.attachments[0].filename  
-                    if 'nslog' in filename and filename.endswith('.txt'):     
-
+                    filename = message.attachments[0].filename
+                    if "nslog" in filename and filename.endswith(".txt"):
                         modsList.clear()
-                        modsListDisabled.clear() 
+                        modsListDisabled.clear()
                         modsDisabledCore.clear()
-                        
+
                         print("Found a log!")
                         if os.path.exists("Logs") == False:
                             os.mkdir("Logs")
-                            
+
                         await message.attachments[0].save("Logs/nslogunparsed.txt")
                         with open(r"Logs/nslogunparsed.txt", "r") as file:
                             lines = file.readlines()
-                            
-                   
+
                             for line in lines:
                                 if "NorthstarLauncher version:" in line:
-                                    
                                     verSplit = line.split("version:")[1]
                                     if verSplit.strip() == "0.0.0.1+dev":
                                         return
                                     elif verSplit.strip() < versionCheck():
-                                        dmLog.add_field(name="", value=f"Version: {verSplit.strip()}", inline=False)
+                                        dmLog.add_field(
+                                            name="",
+                                            value=f"Version: {verSplit.strip()}",
+                                            inline=False,
+                                        )
                                         problemFound = True
                                         oldVersion = True
 
                                 # Check mods
-                                
+
                                 if "(DISABLED)" in line:
-                                    if "Northstar.Client" in line or "Northtar.Custom" in line or "Northstar.CustomServers" in line:
-                                        disabledCoreMod = True 
+                                    if (
+                                        "Northstar.Client" in line
+                                        or "Northtar.Custom" in line
+                                        or "Northstar.CustomServers" in line
+                                    ):
+                                        disabledCoreMod = True
                                         modsDisabledCore.append(line.split("'")[1])
                                     print(line.split("'")[1])
                                     modsListDisabled.append(line.split("'")[1])
 
                                 if "blacklisted mod" in line:
-                                    modsListDisabled.append(line.split('"')[1] + " (blacklisted)\n")
-                                    
-                                if "Loading mod" in line:
+                                    modsListDisabled.append(
+                                        line.split('"')[1] + " (blacklisted)\n"
+                                    )
 
+                                if "Loading mod" in line:
                                     if "R2Northstar" in line:
                                         continue
                                     else:
@@ -169,43 +199,78 @@ class LogReading(commands.Cog):
                                             if mod + "\n" in line:
                                                 continue
                                             else:
-                                                modsList.append(line.split("Loading mod")[1])
+                                                modsList.append(
+                                                    line.split("Loading mod")[1]
+                                                )
 
                                     # Check if HUD Revamp is installed: conflicts with Client Kill callback
                                     if "HUD Revamp" in line:
-                                        dmLog.add_field(name="", value="HUD Revamp: True", inline=False)
+                                        dmLog.add_field(
+                                            name="",
+                                            value="HUD Revamp: True",
+                                            inline=False,
+                                        )
                                         print("I found HUD Revamp!")
                                         hud = True
 
                                     # Check if Client Kill callback is installed: conflicts with HUD Revamp
                                     if "ClientKillCallback" in line:
-                                        dmLog.add_field(name="", value="Client Kill Callback: True", inline=False)
+                                        dmLog.add_field(
+                                            name="",
+                                            value="Client Kill Callback: True",
+                                            inline=False,
+                                        )
                                         print("I found Client Kill Callback!")
                                         problemFound = True
                                         callback = True
 
                                     # Check if the OLD, merged better server browser is loading. It's broken now and causes issues
                                     if "Better.Serverbrowser" in line:
-                                        dmLog.add_field(name="", value="Better.Serverbrowser: True", inline=False)
+                                        dmLog.add_field(
+                                            name="",
+                                            value="Better.Serverbrowser: True",
+                                            inline=False,
+                                        )
                                         print("I found better server browser!")
                                         problemFound = True
                                         betterServerBrowser = True
-                                
+
                                 # Check for a compile error for missing Client Kill callback as a dependency, or when there's a conflict with it
-                                if "COMPILE ERROR expected \",\", found identifier \"inputParams\"" in line:
-                                    dmLog.add_field(name="", value="Client kill callback compile error: True", inline=False)
+                                if (
+                                    'COMPILE ERROR expected ",", found identifier "inputParams"'
+                                    in line
+                                ):
+                                    dmLog.add_field(
+                                        name="",
+                                        value="Client kill callback compile error: True",
+                                        inline=False,
+                                    )
                                     print("I found a compile error!")
                                     problemFound = True
                                     compileErrorClientKillCallback = True
 
-                                if "COMPILE ERROR Undefined variable \"ModSettings_AddDropdown\"" in line:
-                                    dmLog.add_field(name="", value="Missing negativbild: True", inline=False)
+                                if (
+                                    'COMPILE ERROR Undefined variable "ModSettings_AddDropdown"'
+                                    in line
+                                ):
+                                    dmLog.add_field(
+                                        name="",
+                                        value="Missing negativbild: True",
+                                        inline=False,
+                                    )
                                     print("I found a person missing negativbild!")
                                     problemFound = True
                                     rgbError = True
-                                
-                                if "COMPILE ERROR Undefined variable \"NS_InternalLoadFile\"" in line:
-                                    dmLog.add_field(name="", value="Titan Framework issue: True", inline=False)
+
+                                if (
+                                    'COMPILE ERROR Undefined variable "NS_InternalLoadFile"'
+                                    in line
+                                ):
+                                    dmLog.add_field(
+                                        name="",
+                                        value="Titan Framework issue: True",
+                                        inline=False,
+                                    )
                                     print("I found a titan framework issue >:(")
                                     problemFound = True
                                     frameworkError = True
@@ -213,30 +278,41 @@ class LogReading(commands.Cog):
                                 # Check for audio replacements being loaded
                                 # If 2 seperate mods replacing the same audio are enabled at the same time the game fucking kills itself
                                 if "Finished async read of audio sample" in line:
-                                    
                                     if "packages" in line:
-                                    # Split the string after "R2Northstar/mods" to keep the folder name onwards
+                                        # Split the string after "R2Northstar/mods" to keep the folder name onwards
                                         a = line.split("R2Northstar\packages")[1]
                                     if "R2Northstar\mods" in line:
                                         a = line.split("R2Northstar\mods")[1]
-                                    # Split the previous split at "audio" to cleanly format as "FolderName, audioname" 
+                                    # Split the previous split at "audio" to cleanly format as "FolderName, audioname"
                                     # side note: why the fuck don't we use the mod name at all literally anywhere even when registering the audio fully
                                     b = a.split("audio")
                                     # Further clean up the last split
-                                    c = [item.split('\\')[1] for item in b]
-                                    
+                                    c = [item.split("\\")[1] for item in b]
+
                                     # Add these to the audio list for checking for errors
                                     audioList.append(c)
 
-                                if "[NORTHSTAR] [error] Northstar has crashed! a minidump has been written and exception info is available below:" in line: # Checks for first line of the crash section of the log
-                                    checkLine = lines[i - 2] # Stores the previous line (right before the crash), we have to skip the version printout
+                                if (
+                                    "[NORTHSTAR] [error] Northstar has crashed! a minidump has been written and exception info is available below:"
+                                    in line
+                                ):  # Checks for first line of the crash section of the log
+                                    checkLine = lines[
+                                        i - 2
+                                    ]  # Stores the previous line (right before the crash), we have to skip the version printout
                                     crashCounter += 1
-                                    if crashCounter == 2: # More than 1 crash, flip multiCrash to true. Only needs to happen once so check for equality
+                                    if (
+                                        crashCounter == 2
+                                    ):  # More than 1 crash, flip multiCrash to true. Only needs to happen once so check for equality
                                         multiCrash = True
-                                    elif "LoadStreamPak" in checkLine and crashCounter == 1: # Check for paks being loaded right before crash, only search if one crash 
+                                    elif (
+                                        "LoadStreamPak" in checkLine
+                                        and crashCounter == 1
+                                    ):  # Check for paks being loaded right before crash, only search if one crash
                                         modProblem = True
                                         # Use regex to grab the name of the pak that probably failed
-                                        match = re.search(r'LoadStreamPak: (\S+)', checkLine)
+                                        match = re.search(
+                                            r"LoadStreamPak: (\S+)", checkLine
+                                        )
                                         global badStreamPakLoad
                                         badStreamPakLoad = str(match.group(1))
                                         problemFound = True
@@ -244,30 +320,44 @@ class LogReading(commands.Cog):
                                         # this shit is so fucking gross oh my fucking god
                                         # i am so sorry for what i did to your code tony
                                         for lineAgain in lines:
-                                            if f"registered starpak '{badStreamPakLoad}'" in lineAgain:
-                                                   
-                                                match = re.search(r'Mod\s+(.*?)\s+registered', lineAgain)                                               
-                                                badStreamPakLoad = match.group(1) # Store problematic mod in global var
+                                            if (
+                                                f"registered starpak '{badStreamPakLoad}'"
+                                                in lineAgain
+                                            ):
+                                                match = re.search(
+                                                    r"Mod\s+(.*?)\s+registered",
+                                                    lineAgain,
+                                                )
+                                                badStreamPakLoad = match.group(
+                                                    1
+                                                )  # Store problematic mod in global var
 
                                         file.close()
 
-                                        with open(r"Logs/nslogstarpaks.txt", "w") as file1:
-                                            file1.write(f"Bad streampak: {badStreamPakLoad}")
+                                        with open(
+                                            r"Logs/nslogstarpaks.txt", "w"
+                                        ) as file1:
+                                            file1.write(
+                                                f"Bad streampak: {badStreamPakLoad}"
+                                            )
                                             file1.close()
-                                        
-                                        with open(r"Logs/nslogstarpaks.txt", "r") as file2:
+
+                                        with open(
+                                            r"Logs/nslogstarpaks.txt", "r"
+                                        ) as file2:
                                             lines = file2.readlines()
 
                                             for i, line in enumerate(lines):
                                                 if "Bad streampak: " in line:
-                                                    badMod = line.split("Bad streampak: ")[1]
-
+                                                    badMod = line.split(
+                                                        "Bad streampak: "
+                                                    )[1]
 
                                                     # Run back over the log to find what mod the pak is registered with
                                                     if badMod == "Northstar.Custom":
-                                                        doubleBarrelCrash = True             
+                                                        doubleBarrelCrash = True
                                                     file2.close()
-                                                    break # End the loop as it is no longer useful
+                                                    break  # End the loop as it is no longer useful
 
                         # Properly set up the list for actual checking
                         d = list(set(tuple(audio) for audio in audioList))
@@ -283,88 +373,160 @@ class LogReading(commands.Cog):
                             if audio_duplicate in audio_duplicates_list:
                                 audio_duplicates_list[audio_duplicate].append(item[0])
                             else:
-                                audio_duplicates_list[audio_duplicate] = [item[0]]                        
+                                audio_duplicates_list[audio_duplicate] = [item[0]]
 
                         for audio_duplicate, names in audio_duplicates_list.items():
                             if len(names) > 1:
                                 problemFound = True
-                                print(f"Found duplicates of {audio_duplicate}: {', '.join(names)}")
+                                print(
+                                    f"Found duplicates of {audio_duplicate}: {', '.join(names)}"
+                                )
 
                         if problemFound == True:
-                            print("Found problems in the log! Replying...")   
+                            print("Found problems in the log! Replying...")
                             await message.channel.typing()
                             sleep(5)
 
                             if disabledCoreMod == True:
-                                disabledCoreString = ""     
+                                disabledCoreString = ""
 
                                 if len(modsDisabledCore) > 1:
                                     if len(modsDisabledCore) == 2:
                                         for mod in modsDisabledCore:
-                                            disabledCoreString = disabledCoreString + mod       
+                                            disabledCoreString = (
+                                                disabledCoreString + mod
+                                            )
 
-                                    problem.add_field(name="Disabled core mods", value=f"The core mods {disabledCoreString} are disabled! Please re-enable them using a mod manager or by deleting `Titanfall2/R2Northstar/enabledmods.json` (this only applies if trying to play Northstar. If you are playing vanilla via Northstar and encountering an issue, it is something else)", inline=False)
+                                    problem.add_field(
+                                        name="Disabled core mods",
+                                        value=f"The core mods {disabledCoreString} are disabled! Please re-enable them using a mod manager or by deleting `Titanfall2/R2Northstar/enabledmods.json` (this only applies if trying to play Northstar. If you are playing vanilla via Northstar and encountering an issue, it is something else)",
+                                        inline=False,
+                                    )
 
                                 elif len(modsDisabledCore) == 1:
                                     for mod in modsDisabledCore:
                                         disabledCoreString = disabledCoreString + mod
-                                    problem.add_field(name="Disabled core mod", value=f"The core mod {disabledCoreString} is disabled! Please re-enable it using a mod manager or by deleting `Titanfall2/R2Northstar/enabledmods.json` (this only applies if trying to play Northstar. If you are playing vanilla via Northstar and encountering an issue, it is something else)", inline=False)
-      
-                            if hud == True and callback == True and compileErrorClientKillCallback == True:
-                                problem.add_field(name="", value="I noticed you have both HUD Revamp and Client Kill Callback installed. Currently, these two mods create conflicts. The easiest way to solve this is to delete/disable HUD Revamp.", inline=False)
+                                    problem.add_field(
+                                        name="Disabled core mod",
+                                        value=f"The core mod {disabledCoreString} is disabled! Please re-enable it using a mod manager or by deleting `Titanfall2/R2Northstar/enabledmods.json` (this only applies if trying to play Northstar. If you are playing vanilla via Northstar and encountering an issue, it is something else)",
+                                        inline=False,
+                                    )
+
+                            if (
+                                hud == True
+                                and callback == True
+                                and compileErrorClientKillCallback == True
+                            ):
+                                problem.add_field(
+                                    name="",
+                                    value="I noticed you have both HUD Revamp and Client Kill Callback installed. Currently, these two mods create conflicts. The easiest way to solve this is to delete/disable HUD Revamp.",
+                                    inline=False,
+                                )
 
                             else:
-                                
                                 if compileErrorClientKillCallback:
-                                    problem.add_field(name="Missing dependency!", value="One or more mods you have may require the mod [Client killcallback](https://northstar.thunderstore.io/package/S2Mods/KraberPrimrose/) to work. Please install or update the mod via a mod manager or Thunderstore.", inline=False)
+                                    problem.add_field(
+                                        name="Missing dependency!",
+                                        value="One or more mods you have may require the mod [Client killcallback](https://northstar.thunderstore.io/package/S2Mods/KraberPrimrose/) to work. Please install or update the mod via a mod manager or Thunderstore.",
+                                        inline=False,
+                                    )
 
                             if rgbError == True:
-                                problem.add_field(name="Missing dependency!",value="One or more mods you have may require the mod [Negativbild](https://northstar.thunderstore.io/package/odds/Negativbild/) to work. Please install or update this mod via a mod manager or Thundersore")
-                            
+                                problem.add_field(
+                                    name="Missing dependency!",
+                                    value="One or more mods you have may require the mod [Negativbild](https://northstar.thunderstore.io/package/odds/Negativbild/) to work. Please install or update this mod via a mod manager or Thundersore",
+                                )
+
                             if frameworkError == True:
-                                problem.add_field(name="Titan Framework", value="Currently, Titan Framework expects a work in progress Northstar feature to function. As such, having it installed will cause issues (temporarily, until the feature is implemented), which uninstalling it will fix. You can temporarily make it work by manually installing the mod by moving the plugins inside the `plugins` folder of the mod into `r2northstar/plugins`, however this is a TEMPORARY fix, and you'll have to undo it when Northstar gets its next update.", inline=False)
+                                problem.add_field(
+                                    name="Titan Framework",
+                                    value="Currently, Titan Framework expects a work in progress Northstar feature to function. As such, having it installed will cause issues (temporarily, until the feature is implemented), which uninstalling it will fix. You can temporarily make it work by manually installing the mod by moving the plugins inside the `plugins` folder of the mod into `r2northstar/plugins`, however this is a TEMPORARY fix, and you'll have to undo it when Northstar gets its next update.",
+                                    inline=False,
+                                )
 
                             if betterServerBrowser == True:
-                                problem.add_field(name="Better server browser", value="There are two mods called better server browser. The one called \"Better.Serverbrowser\" causes issues when installed, as it was added to Northstar a while ago. Removing it should fix that specific issue.")
+                                problem.add_field(
+                                    name="Better server browser",
+                                    value='There are two mods called better server browser. The one called "Better.Serverbrowser" causes issues when installed, as it was added to Northstar a while ago. Removing it should fix that specific issue.',
+                                )
 
                             for audio_duplicate, names in audio_duplicates_list.items():
                                 if len(names) > 1:
                                     audioProblem = True
-                                    problem.add_field(name="Audio replacement conflict", value=f"The following mods replace the same audio (`{audio_duplicate}`):\n {', '.join(names)}", inline=False)
-                                    dmLog.add_field(name="Audio replacement conflict", value=f"The following mods replace the same audio (`{audio_duplicate}`):\n {', '.join(names)}", inline=False)
-
+                                    problem.add_field(
+                                        name="Audio replacement conflict",
+                                        value=f"The following mods replace the same audio (`{audio_duplicate}`):\n {', '.join(names)}",
+                                        inline=False,
+                                    )
+                                    dmLog.add_field(
+                                        name="Audio replacement conflict",
+                                        value=f"The following mods replace the same audio (`{audio_duplicate}`):\n {', '.join(names)}",
+                                        inline=False,
+                                    )
 
                             if oldVersion == True:
-                                problem.add_field(name="Older Version", value=f"It seems that you're running an older version of Northstar. Updating may not solve your issue, but you should do it anyway. The current version is {versionCheck()}. Please update by using one of the methods in the [installation channel](https://discord.com/channels/920776187884732556/922662496588943430).", inline=False)
-                                problem.add_field(name="\u200b", value="If you've already updated and are still seeing this, please check if you have a file called `northstar.dll` in `titanfall2/R2Northstar`. If you do, delete it, and try launching again.", inline=False)
+                                problem.add_field(
+                                    name="Older Version",
+                                    value=f"It seems that you're running an older version of Northstar. Updating may not solve your issue, but you should do it anyway. The current version is {versionCheck()}. Please update by using one of the methods in the [installation channel](https://discord.com/channels/920776187884732556/922662496588943430).",
+                                    inline=False,
+                                )
+                                problem.add_field(
+                                    name="\u200b",
+                                    value="If you've already updated and are still seeing this, please check if you have a file called `northstar.dll` in `titanfall2/R2Northstar`. If you do, delete it, and try launching again.",
+                                    inline=False,
+                                )
 
-                            
                             if audioProblem == True:
-                                problem.add_field(name="Fixing audio replacement conflicts", value="Please remove mods until only one of these audio mods are enabled. These names aren't perfect to what they are for the mod, however they are the file names for the mod, so you can just remove the folder matching the name from `Titanfall2/R2Northstar/mods`.", inline=False)
+                                problem.add_field(
+                                    name="Fixing audio replacement conflicts",
+                                    value="Please remove mods until only one of these audio mods are enabled. These names aren't perfect to what they are for the mod, however they are the file names for the mod, so you can just remove the folder matching the name from `Titanfall2/R2Northstar/mods`.",
+                                    inline=False,
+                                )
 
-                            if modProblem == True:  
+                            if modProblem == True:
                                 if doubleBarrelCrash == True:
-
-                                    problem.add_field(name="Mod crashing", value= "Northstar crashed right after loading the double barrel assets.\nPlease try deleting `w_shotgun_doublebarrel.mdl` from `Titanfall2/R2Northstar/mods/Northstar.Custom/mod/models/weapon/shotgun_doublebarrel`.\nDoing this will solve this specific crash, but will make you hold an error when trying to use the double barrel in game.")
+                                    problem.add_field(
+                                        name="Mod crashing",
+                                        value="Northstar crashed right after loading the double barrel assets.\nPlease try deleting `w_shotgun_doublebarrel.mdl` from `Titanfall2/R2Northstar/mods/Northstar.Custom/mod/models/weapon/shotgun_doublebarrel`.\nDoing this will solve this specific crash, but will make you hold an error when trying to use the double barrel in game.",
+                                    )
 
                                 else:
+                                    problem.add_field(
+                                        name="Mod crashing",
+                                        value=f"Northstar crashed right after attempting to load as asset from the mod `{badMod}`. Please try removing/disabling this mod to see if this solves the issue.",
+                                    )
 
-                                    problem.add_field(name="Mod crashing", value=f"Northstar crashed right after attempting to load as asset from the mod `{badMod}`. Please try removing/disabling this mod to see if this solves the issue.")
-                            
-                            problem.add_field(name="", value="Please note that I am a bot and am still heavily being worked on. There is a chance that some or all of this information is incorrect, in which case I apologize.\nIf you still encounter issues after doing this, please send another log.", inline=False)
-                            await message.channel.send(embed=problem, reference=message)     
-                            
+                            problem.add_field(
+                                name="",
+                                value="Please note that I am a bot and am still heavily being worked on. There is a chance that some or all of this information is incorrect, in which case I apologize.\nIf you still encounter issues after doing this, please send another log.",
+                                inline=False,
+                            )
+                            await message.channel.send(embed=problem, reference=message)
+
                             dmme = await self.bot.fetch_user(self.bot.owner_id)
 
                             if len(problem.fields) > 0:
-                                problem.add_field(name="", value="Please note that I am a bot and am still heavily being worked on. There is a chance that some or all of this information is incorrect, in which case I apologize.\nIf you still encounter issues after doing this, please send another log.", inline=False)
-                                await message.channel.send(embed=problem, reference=message, view=view)     
-                                dmLog.add_field(name="I found an issue in the log and replied!", value=f"A link to their log can be found here: {message.jump_url}")
+                                problem.add_field(
+                                    name="",
+                                    value="Please note that I am a bot and am still heavily being worked on. There is a chance that some or all of this information is incorrect, in which case I apologize.\nIf you still encounter issues after doing this, please send another log.",
+                                    inline=False,
+                                )
+                                await message.channel.send(
+                                    embed=problem, reference=message, view=view
+                                )
+                                dmLog.add_field(
+                                    name="I found an issue in the log and replied!",
+                                    value=f"A link to their log can be found here: {message.jump_url}",
+                                )
                                 await dmme.send(embed=dmLog)
                             else:
-                                await dmme.send(f"I failed to respond to a log! The log can be found here: {message.jump_url}")
-                                await message.channel.send("I failed to respond to the log properly!")
-                                
+                                await dmme.send(
+                                    f"I failed to respond to a log! The log can be found here: {message.jump_url}"
+                                )
+                                await message.channel.send(
+                                    "I failed to respond to the log properly!"
+                                )
+
                             dmLog.clear_fields()
 
                             audio_duplicates_list.clear()
@@ -379,17 +541,21 @@ class LogReading(commands.Cog):
                             betterServerBrowser = False
                             oldVersion = False
                             modProblem = False
-                            badMod = ""  
+                            badMod = ""
 
                         elif problemFound == False:
                             dmme = await self.bot.fetch_user(self.bot.owner_id)
-                            dmLog.add_field(name="I didn't find any issues!", value=f"Here's a log you could potentially train from: {message.jump_url}")
+                            dmLog.add_field(
+                                name="I didn't find any issues!",
+                                value=f"Here's a log you could potentially train from: {message.jump_url}",
+                            )
                             await dmme.send(embed=dmLog)
                             dmLog.clear_fields()
 
                             print("I didn't find any problems in the log!")
 
                         shutil.rmtree("Logs")
-            
+
+
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(LogReading(bot))

--- a/cogs/MasterCheck.py
+++ b/cogs/MasterCheck.py
@@ -3,9 +3,9 @@ import util.MasterStatus
 
 
 class MasterCheck(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        
+
     @commands.hybrid_command(description="Check Northstar master server status")
     async def ms_status(self, ctx):
         if util.MasterStatus.IsMasterDown() is True:
@@ -17,6 +17,7 @@ class MasterCheck(commands.Cog):
         else:
             await ctx.send("Spectre encountered an exception while talking to MS")
             return
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(MasterCheck(bot))

--- a/cogs/ModSearch.py
+++ b/cogs/ModSearch.py
@@ -4,73 +4,84 @@ import discord, asyncio
 from discord import app_commands
 from typing import Optional
 
+
 class PaginationView(discord.ui.View):
-    
-    current_page : int = 0
-    
+    current_page: int = 0
+
     async def send(self, ctx):
-        self.message = await ctx.send(embed=self.create_embed(self.data, self.data_key), view=self)
-        
+        self.message = await ctx.send(
+            embed=self.create_embed(self.data, self.data_key), view=self
+        )
+
     def create_embed(self, data, data_key):
         key = self.data_key[self.current_page]
         mod = self.data[key]
         mod_embed_desc = f"By {mod['owner']}\n{mod['description']}"
         embed_title = f"{mod['name']} ({self.current_page + 1}/{len(self.data_key)})"
         embed_footer = f"{mod['total_dl']} Downloads | Last updated on {mod['last_update']} (YY/MM/DD)"
-        embed = discord.Embed(
-            title=embed_title,
-            description=mod_embed_desc
-        )
-        embed.set_thumbnail(url=mod['icon_url'])
+        embed = discord.Embed(title=embed_title, description=mod_embed_desc)
+        embed.set_thumbnail(url=mod["icon_url"])
         embed.set_footer(text=embed_footer)
-        self.mod_url = mod['ts_url']
+        self.mod_url = mod["ts_url"]
         return embed
-    
+
     async def update_message(self, data, data_key):
         await self.message.edit(embed=self.create_embed(data, data_key), view=self)
-    
+
     @discord.ui.button(label="View Mod", style=discord.ButtonStyle.success)
-    async def link_button(self, interaction:discord.Interaction, button: discord.ui.Button):
+    async def link_button(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         await interaction.response.send_message(self.mod_url, ephemeral=True)
-    
+
     @discord.ui.button(label="Prev", style=discord.ButtonStyle.primary)
-    async def prev_button(self, interaction:discord.Interaction, button: discord.ui.Button):
+    async def prev_button(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         await interaction.response.defer()
         self.current_page = (self.current_page - 1) % len(self.data_key)
         await self.update_message(self.data, self.data_key)
-    
+
     @discord.ui.button(label="Next", style=discord.ButtonStyle.primary)
-    async def next_button(self, interaction:discord.Interaction, button: discord.ui.Button):
+    async def next_button(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ):
         await interaction.response.defer()
         self.current_page = (self.current_page + 1) % len(self.data_key)
         await self.update_message(self.data, self.data_key)
 
+
 class ModSearch(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
-        self.bot = bot 
-        
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
     @commands.hybrid_command(description="Search Northstar Thunderstore for mods")
-    @app_commands.choices(method=[
-        app_commands.Choice(name="Mod name", value="name"),
-        app_commands.Choice(name="Mod author", value="owner")
-        ])
-    async def modsearch(self, ctx, search_string: str, method: Optional[app_commands.Choice[str]]):
-        
+    @app_commands.choices(
+        method=[
+            app_commands.Choice(name="Mod name", value="name"),
+            app_commands.Choice(name="Mod author", value="owner"),
+        ]
+    )
+    async def modsearch(
+        self, ctx, search_string: str, method: Optional[app_commands.Choice[str]]
+    ):
         if len(search_string) < 3:
-            character_warning = await ctx.send("Search must be at least 3 characters", ephemeral=True)
+            character_warning = await ctx.send(
+                "Search must be at least 3 characters", ephemeral=True
+            )
             await asyncio.sleep(5)
             await character_warning.delete()
             return
-        
+
         try:
             response = requests.get("https://northstar.thunderstore.io/api/v1/package/")
             if response.status_code == 200:
                 data = response.json()
-    
+
         except requests.exceptions.RequestException as err:
             print(err)
             return
-        
+
         mods = {}
         for i, item in enumerate(data):
             if method == "owner":
@@ -78,32 +89,38 @@ class ModSearch(commands.Cog):
             else:
                 match = re.search(search_string, item["name"], re.IGNORECASE)
             if match:
-                if item['has_nsfw_content']: # Prevent mods labelled as containing NSFW content from appearing in searches
+                if item[
+                    "has_nsfw_content"
+                ]:  # Prevent mods labelled as containing NSFW content from appearing in searches
                     continue
                 downloads = 0
-                for version in item['versions']:
-                    downloads = downloads + version['downloads']
-                mods[item['owner'] + "." + item['name']] = {
-                    "name": item['name'].replace("_", " "),
-                    "owner": item['owner'],
-                    "icon_url": item['versions'][0]['icon'],
-                    "ts_url": item['package_url'],
-                    "last_update": item['date_updated'][:(item['date_updated'].index('T'))], # Remove time from date string
+                for version in item["versions"]:
+                    downloads = downloads + version["downloads"]
+                mods[item["owner"] + "." + item["name"]] = {
+                    "name": item["name"].replace("_", " "),
+                    "owner": item["owner"],
+                    "icon_url": item["versions"][0]["icon"],
+                    "ts_url": item["package_url"],
+                    "last_update": item["date_updated"][
+                        : (item["date_updated"].index("T"))
+                    ],  # Remove time from date string
                     "total_dl": downloads,
-                    "description": item['versions'][0]['description']
+                    "description": item["versions"][0]["description"],
                 }
-                
+
         if not mods:
             no_mods_warning = await ctx.send("No mods found")
             await asyncio.sleep(5)
             await no_mods_warning.delete()
             return
-        
-        # Sort mods by most downloaded by default until we get better sorting later        
-        sorted_mods_by_dl = dict(sorted(mods.items(), key=lambda item: item[1]['total_dl'], reverse=True))
-        
+
+        # Sort mods by most downloaded by default until we get better sorting later
+        sorted_mods_by_dl = dict(
+            sorted(mods.items(), key=lambda item: item[1]["total_dl"], reverse=True)
+        )
+
         pages = list(sorted_mods_by_dl.keys())
-        
+
         pagination_view = PaginationView()
         pagination_view.data_key = pages
         pagination_view.data = sorted_mods_by_dl

--- a/cogs/PlaytesterPing.py
+++ b/cogs/PlaytesterPing.py
@@ -7,10 +7,9 @@ import os
 url = "https://api.github.com/graphql"
 githubAccessToken = os.getenv("githubAccessToken")
 
+
 def getLatestDiscussion():
-    headers = {
-        "Authorization": f"Bearer {githubAccessToken}"
-    }
+    headers = {"Authorization": f"Bearer {githubAccessToken}"}
 
     query = """
     query {
@@ -36,39 +35,50 @@ def getLatestDiscussion():
         response = requests.post(url, json={"query": query}, headers=headers)
         if response.status_code == 200:
             raw_data = response.json()
-            
+
     except requests.exceptions.RequestException as err:
         print(f"GitHub API request failed: {err}")
         return None
-    
+
     discussion_post = {
-        'author': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["author"]["login"],
-        'title': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["title"],
-        'body': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["body"],
-        'number': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["number"],
-        'url': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["url"]
+        "author": raw_data["data"]["repository"]["discussions"]["edges"][0]["node"][
+            "author"
+        ]["login"],
+        "title": raw_data["data"]["repository"]["discussions"]["edges"][0]["node"][
+            "title"
+        ],
+        "body": raw_data["data"]["repository"]["discussions"]["edges"][0]["node"][
+            "body"
+        ],
+        "number": raw_data["data"]["repository"]["discussions"]["edges"][0]["node"][
+            "number"
+        ],
+        "url": raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["url"],
     }
-    
+
     return discussion_post
 
+
 def getLatestReleaseName():
-    headers = {
-        "Authorization": f"Bearer {githubAccessToken}"
-    }
+    headers = {"Authorization": f"Bearer {githubAccessToken}"}
 
     try:
-        response = requests.get("https://api.github.com/repos/R2Northstar/NorthstarLauncher/releases", headers=headers)
-            
+        response = requests.get(
+            "https://api.github.com/repos/R2Northstar/NorthstarLauncher/releases",
+            headers=headers,
+        )
+
     except requests.exceptions.RequestException as err:
         print(f"GitHub API request failed: {err}")
         return None
-    
+
     return response.json()[0]["tag_name"]
 
+
 class PlayTesterPing(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        
+
     @commands.Cog.listener()
     async def on_message(self, message):
         playtestPingChannel = self.bot.get_channel(936678773150081055)
@@ -80,19 +90,28 @@ class PlayTesterPing(commands.Cog):
         if message.channel == thunderstoreReleaseChannel:
             if not message.embeds:
                 return
-            if re.search(r'NorthstarReleaseCandidate v\d+.\d+.\d+', message.embeds[0].title) and message.embeds[0].author.name == "northstar":
+            if (
+                re.search(
+                    r"NorthstarReleaseCandidate v\d+.\d+.\d+", message.embeds[0].title
+                )
+                and message.embeds[0].author.name == "northstar"
+            ):
                 data = getLatestDiscussion()
                 rcVersion = getLatestReleaseName()
-                
-                embed = discord.Embed(
-                    title="Changelog:",
-                    description=data["body"]
+
+                embed = discord.Embed(title="Changelog:", description=data["body"])
+
+                embed.set_author(
+                    name="Northstar " + rcVersion,
+                    icon_url="https://avatars.githubusercontent.com/u/86304187",
                 )
 
-                embed.set_author(name="Northstar " + rcVersion, icon_url="https://avatars.githubusercontent.com/u/86304187")
-                
-                pingMessage = await playtestPingChannel.send(f"<@&936669179359141908>, there is a new Northstar release candidate, `{rcVersion}`. If you find any issues or have feedback, please inform us in the thread attached to this message.\n\n**Installation**:\nGo to settings in FlightCore, and enable testing release channels (you only need to do this once). After you've done that, go to the play tab, click the arrow next to `LAUNCH GAME`, and select `Northstar release candidate`. Then, click the `UPDATE` button.", embed=embed)
+                pingMessage = await playtestPingChannel.send(
+                    f"<@&936669179359141908>, there is a new Northstar release candidate, `{rcVersion}`. If you find any issues or have feedback, please inform us in the thread attached to this message.\n\n**Installation**:\nGo to settings in FlightCore, and enable testing release channels (you only need to do this once). After you've done that, go to the play tab, click the arrow next to `LAUNCH GAME`, and select `Northstar release candidate`. Then, click the `UPDATE` button.",
+                    embed=embed,
+                )
                 await pingMessage.create_thread(name=rcVersion)
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(PlayTesterPing(bot))

--- a/cogs/PriceCheck.py
+++ b/cogs/PriceCheck.py
@@ -5,18 +5,23 @@ from discord import app_commands
 
 TF2_STORE_STEAMAPI_URL = "https://store.steampowered.com/api/appdetails?appids=1237970"
 
+
 class PriceCheck(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        
-    @commands.hybrid_command(description="Display current price of Titanfall 2 on Steam")
-    @app_commands.choices(region=[
-        app_commands.Choice(name="US", value="US"),
-        app_commands.Choice(name="EU", value="DE"),
-        app_commands.Choice(name="CA", value="CA"),
-        app_commands.Choice(name="AU", value="AU"),
-        app_commands.Choice(name="GB", value="GB"),
-        ])
+
+    @commands.hybrid_command(
+        description="Display current price of Titanfall 2 on Steam"
+    )
+    @app_commands.choices(
+        region=[
+            app_commands.Choice(name="US", value="US"),
+            app_commands.Choice(name="EU", value="DE"),
+            app_commands.Choice(name="CA", value="CA"),
+            app_commands.Choice(name="AU", value="AU"),
+            app_commands.Choice(name="GB", value="GB"),
+        ]
+    )
     async def price(self, ctx, region: typing.Optional[app_commands.Choice[str]]):
         # Initial request sent to the Steam API to make sure TF2 is on sale
         # Price values are returned via bs4 scraping so we can have regional prices
@@ -38,7 +43,7 @@ class PriceCheck(commands.Cog):
 
         if sale_percent != 0:
             base_url = "https://store.steampowered.com/app/1237970/Titanfall_2/?cc="
-            
+
             if region is None:
                 try:
                     response = requests.get(base_url + "US")
@@ -47,63 +52,63 @@ class PriceCheck(commands.Cog):
                         message = f"Web request returned code: {response.status_code}"
                         await ctx.send(message)
                         return
-                    
+
                 except requests.exceptions.RequestException as err:
                     message = f"Web request failed: {err}"
                     await ctx.send(message)
                     return
-                
+
             else:
                 try:
                     response = requests.get(base_url + region.value)
-                    
+
                     if response.status_code != 200:
                         message = f"Web request returned code: {response.status_code}"
                         await ctx.send(message)
                         return
-                    
+
                 except requests.exceptions.RequestException as err:
                     message = f"Web request failed: {err}"
                     await ctx.send(message)
                     return
-                
+
             soup = BeautifulSoup(response.content, "lxml")
             final_price = soup.find("div", class_="discount_final_price")
             standard_price = soup.find("div", class_="discount_original_price")
             message = f"Titanfall 2 is **ON SALE for {str(sale_percent)}% OFF**!\nStandard Price: **{standard_price.text.strip()}**\nSale Price: **{final_price.text.strip()}**\n<https://store.steampowered.com/app/1237970/Titanfall_2/>"
             await ctx.send(message)
             return
-        
+
         else:
             base_url = "https://store.steampowered.com/app/1237970/Titanfall_2/?cc="
             if region is None:
                 try:
                     response = requests.get(base_url + "US")
-                    
+
                     if response.status_code != 200:
                         message = f"Web request returned code: {response.status_code}"
                         await ctx.send(message)
                         return
-                    
+
                 except requests.exceptions.RequestException as err:
                     message = f"Web request failed: {err}"
                     await ctx.send(message)
                     return
-                        
+
             else:
                 try:
                     response = requests.get(base_url + region.value)
-                    
+
                     if response.status_code != 200:
                         message = f"Web request returned code: {response.status_code}"
                         await ctx.send(message)
                         return
-                    
+
                 except requests.exceptions.RequestException as err:
                     message = f"Web request failed: {err}"
                     await ctx.send(message)
                     return
-                
+
             soup = BeautifulSoup(response.content, "lxml")
             standard_price = soup.find("div", class_="game_purchase_price")
             message = f"Titanfall 2 is **not** on sale.\nCurrent Price: **{standard_price.text.strip()}**\n<https://store.steampowered.com/app/1237970/Titanfall_2/>"

--- a/cogs/UserReplies.py
+++ b/cogs/UserReplies.py
@@ -5,45 +5,65 @@ from discord import app_commands
 
 allowed_users = util.JsonHandler.load_allowed_users()
 
+
 class UserReplies(commands.Cog):
-    def __init__(self, bot :commands.Bot) -> None:
+    def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
 
     # Slash command to disable replies for the user
-    @commands.hybrid_command(description='Toggles replies for the user who uses the command')
+    @commands.hybrid_command(
+        description="Toggles replies for the user who uses the command"
+    )
     async def togglereplies(self, ctx):
         data = util.JsonHandler.load_users()
 
         if str(ctx.author.id) in data:
             del data[str(ctx.author.id)]
-            await ctx.send("Succesfully enabled me automatically replying to your messages!", ephemeral=True)
-            
-        else:    
+            await ctx.send(
+                "Succesfully enabled me automatically replying to your messages!",
+                ephemeral=True,
+            )
+
+        else:
             data[str(ctx.author.id)] = f"{ctx.author.display_name}"
-            await ctx.send("Successfully disabled me automatically replying to your messages!", ephemeral=True)
-            
+            await ctx.send(
+                "Successfully disabled me automatically replying to your messages!",
+                ephemeral=True,
+            )
+
         util.JsonHandler.save_users(data)
-    
+
     # Disable a user's automatic replies if they're being naughty :D
-    @commands.hybrid_command(description="Disables reply toggling for selected user. Allowed users only.")
-    @app_commands.describe(user = "The user to disable reply toggling for")
+    @commands.hybrid_command(
+        description="Disables reply toggling for selected user. Allowed users only."
+    )
+    @app_commands.describe(user="The user to disable reply toggling for")
     async def toggleuserreplies(self, ctx, user: discord.Member):
         data = util.JsonHandler.load_neverusers()
-    
+
         if str(ctx.author.id) in allowed_users:
             if str(user.id) in data:
                 del data[str(user.id)]
 
-                await ctx.send(f"Successfully enabled reply toggling for {user.name}!", ephemeral=True)
-        
+                await ctx.send(
+                    f"Successfully enabled reply toggling for {user.name}!",
+                    ephemeral=True,
+                )
+
             else:
                 data[str(user.id)] = "off"
                 # This isn't very efficient but it works (I think)!
-                await ctx.send(f"Successfully disabled reply toggling for {user.name}!", ephemeral=True)
+                await ctx.send(
+                    f"Successfully disabled reply toggling for {user.name}!",
+                    ephemeral=True,
+                )
 
             util.JsonHandler.save_neverusers(data)
         else:
-            await ctx.send("You don't have permission to use this command!", ephemeral=True)
+            await ctx.send(
+                "You don't have permission to use this command!", ephemeral=True
+            )
+
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(UserReplies(bot))

--- a/updateSpectre.py
+++ b/updateSpectre.py
@@ -8,36 +8,39 @@ cwd = os.getcwd()
 # Check that we're actually in the Spectre directory
 if os.path.isfile("Spectre.py") == True:
     # Check that data exists. This could still error out if you don't have one of the other two, but if you don't, what are you doing
-    if os.path.exists("data")  and os.path.isfile(".env") == True:
-        whatUpdate = input("Update moves your current data to a new clone of the up to date Spectre repo, test clones a repo and moves your data to that folder, and restore can be used inside a cloned repo to move data back to the original Spectre folder. What would you like to do? [update]/[test]/[restore] ")
+    if os.path.exists("data") and os.path.isfile(".env") == True:
+        whatUpdate = input(
+            "Update moves your current data to a new clone of the up to date Spectre repo, test clones a repo and moves your data to that folder, and restore can be used inside a cloned repo to move data back to the original Spectre folder. What would you like to do? [update]/[test]/[restore] "
+        )
         if whatUpdate.lower() == "update":
-
-            warning = input("Warning! Running this command updates Spectre, which will remove any local code changes you have! Do you wish to continue? [y]/[n] ")
+            warning = input(
+                "Warning! Running this command updates Spectre, which will remove any local code changes you have! Do you wish to continue? [y]/[n] "
+            )
 
             if warning.lower() == "y":
                 # Move to the parent directory (to create the new directory and later delete the old ones)
                 os.chdir("../")
                 os.rename("Spectre", "SpectreOld")
                 os.mkdir("Spectre")
-        
+
                 # Clone the newest GitHub repo version
                 Repo.clone_from("https://github.com/itscynxx/Spectre", "Spectre")
-        
+
                 # Remove the "new" config file. There might be a better way to do this, but this works
                 os.remove("Spectre/config.json")
-        
+
                 # Move the old data files from the temporary folder into the new Spectre folder
                 shutil.move("SpectreOld/data", "Spectre/data")
                 shutil.move("SpectreOld/.env", "Spectre")
                 shutil.move("SpectreOld/config.json", "Spectre")
-        
+
                 # Print that the system hasn't imploded yet
                 print("Moved Spectre's data files succesfully!")
                 print("Deleting old Spectre files...")
-        
+
                 # Remove temporary folders
                 shutil.rmtree("SpectreOld")
-                
+
             elif warning.lower() == "n":
                 print("Stopping update...")
 
@@ -45,8 +48,9 @@ if os.path.isfile("Spectre.py") == True:
                 print("Unrecognized input given, stopping update...")
 
         if whatUpdate.lower() == "test":
-
-            whatRepo = input("Please paste the url of the branch or repo you want to test. ")
+            whatRepo = input(
+                "Please paste the url of the branch or repo you want to test. "
+            )
             # Make sure the link has Spectre in the name
             if "Spectre" in whatRepo:
                 # If tree is in the name, auto clone
@@ -54,15 +58,17 @@ if os.path.isfile("Spectre.py") == True:
                     print("Branch url found! Automatically cloning the branch url...")
                     # Split on tree, so we get the base url
                     gitUrl = whatRepo.split("/tree")[0]
-                    # Split after tree, so we get the branch 
-                    gitBranch = whatRepo.split("tree/")[1]  
+                    # Split after tree, so we get the branch
+                    gitBranch = whatRepo.split("tree/")[1]
 
-                # If tree isn't in the name, manually input branch name           
+                # If tree isn't in the name, manually input branch name
                 else:
                     # We already have the url in this case
                     gitUrl = whatRepo
                     # Just getting the branch we need
-                    manualBranch = input("Base repo found! Please enter the name of the branch you'd like to clone (leave blank for main) ")
+                    manualBranch = input(
+                        "Base repo found! Please enter the name of the branch you'd like to clone (leave blank for main) "
+                    )
                     if manualBranch is not None:
                         # Setting the common variable to the manually inputted one
                         gitBranch = manualBranch
@@ -71,12 +77,14 @@ if os.path.isfile("Spectre.py") == True:
                         gitBranch = "main"
                 os.chdir("../")
                 # Clone from given url, given branch, and put the repo clone and data into a folder matching the branch name
-                Repo.clone_from(url=gitUrl, branch=gitBranch, to_path=f"Spectre-Branch_{gitBranch}")
+                Repo.clone_from(
+                    url=gitUrl, branch=gitBranch, to_path=f"Spectre-Branch_{gitBranch}"
+                )
                 os.remove(f"Spectre-Branch_{gitBranch}/config.json")
                 shutil.move("Spectre/data", f"Spectre-Branch_{gitBranch}/data")
                 shutil.move("Spectre/.env", f"Spectre-Branch_{gitBranch}")
                 shutil.move("Spectre/config.json", f"Spectre-Branch_{gitBranch}")
-                
+
             else:
                 print("Clone a valid Spectre repo :P")
 
@@ -91,7 +99,9 @@ if os.path.isfile("Spectre.py") == True:
                         shutil.move(f"{cwd}/data", "../Spectre/data")
                         shutil.move(f"{cwd}/.env", "../Spectre")
                         shutil.move(f"{cwd}/config.json", "../Spectre")
-                        removeData = input("Finished moving data files! Would you like to delete the cloned repo's files? [y]/[n] ")
+                        removeData = input(
+                            "Finished moving data files! Would you like to delete the cloned repo's files? [y]/[n] "
+                        )
                         if removeData.lower() == "y":
                             print("Removing cloned repo's files...")
                             shutil.rmtree(cwd)
@@ -100,7 +110,7 @@ if os.path.isfile("Spectre.py") == True:
                     else:
                         print(f"No original Spectre folder found in {cwd('../')}")
             else:
-                print("Run \"Restore\" in a cloned testing repo!")
+                print('Run "Restore" in a cloned testing repo!')
     else:
         print("Run the file inside the Spectre directory that has your data!")
 else:

--- a/util/JsonHandler.py
+++ b/util/JsonHandler.py
@@ -2,7 +2,6 @@ import json
 import os
 
 
-
 def init_json():
     if os.path.isfile(noreplylist) == False:
         new_json(noreplylist)
@@ -13,43 +12,54 @@ def init_json():
     if os.path.isfile(allowedusers) == False:
         new_json(allowedusers)
 
+
 def new_json(name):
     fp = open(name, "w")
     fp.write("{}")
     fp.close()
 
-def save_json(file,data):
-    with open(file, 'w') as f:
+
+def save_json(file, data):
+    with open(file, "w") as f:
         json.dump(data, f, indent=4)
 
+
 def load_json(file):
-    with open(file, 'r') as f:
+    with open(file, "r") as f:
         data = json.load(f)
     return data
-    
+
+
 # Functions for saving users toggling their replies to JSON
 def save_users(data):
     save_json(noreplylist, data)
 
+
 def load_users():
     return load_json(noreplylist)
+
 
 # Functions for saving me toggling user abilities to toggle replies to JSON
 def save_neverusers(data):
     save_json(neverreplylist, data)
 
+
 def load_neverusers():
     return load_json(neverreplylist)
+
 
 # Functions for saving allowed channels to JSON
 def save_channels(data):
     save_json(allowedchannels, data)
 
+
 def load_channels():
     return load_json(allowedchannels)
 
+
 def save_allowed_users(data):
     save_json(allowedusers, data)
+
 
 def load_allowed_users():
     return load_json(allowedusers)

--- a/util/MasterStatus.py
+++ b/util/MasterStatus.py
@@ -2,6 +2,7 @@ import requests
 
 NS_MASTER_SERVER_URL = "https://northstar.tf/client/servers"
 
+
 def IsMasterDown():
     try:
         ms_response = requests.get(NS_MASTER_SERVER_URL)


### PR DESCRIPTION
Marking this pull request as it is mostly for discussion etc.

Basically I propose formatting the entire project with [black](https://pypi.org/project/black/). Basically `black` is an opinionated code formatter.

Assuming you are ok with it's styling (it can probably be adjusted, I didn't check) we could then also add it as a dev dependency and configure a CI that checks PRs and pushes if they adhere to formatting.

This way we can prevent PRs adding trailing whitespaces and other various formatting issues.

For formatting the entire project, one would basically do all the entire changes in a single commit, either by running formatter (`black .`) and pushing straight to `main` or merging this PR and then in a second commit adding a file that tells `git blame` to ignore the formatting commit so that line ownership in `git blame` is still correct.

An example of how we did it in [NorthstarLauncher](https://github.com/R2Northstar/NorthstarLauncher/):
- Formatting commit: https://github.com/R2Northstar/NorthstarLauncher/commit/75bf194b2fca06de805a7bc025c6dd8379250fa5
- Ignore rev file: https://github.com/R2Northstar/NorthstarLauncher/blob/bb822b7638d5ae9bc4499ff76edc74f3741e6518/.git-blame-ignore-revs
