### PR TITLE
Modify `getLatestDiscussion()` function and playtester ping message

### DIFF
--- a/cogs/PlaytesterPing.py
+++ b/cogs/PlaytesterPing.py
@@ -84,7 +84,7 @@ class PlayTesterPing(commands.Cog):
                     f"""<@&936669179359141908>
 There is a new Northstar release candidate, `{rcVersion}`. If you find any issues or have feedback, please inform us in the thread attached to this message.
 ## **Installation**:
-**If you have __not__ installed a release candidate before**
+**If you have __not__ installed a release candidate before:**
 Go to settings in FlightCore, and enable testing release channels. After you've done that, go to the play tab, click the arrow next to `LAUNCH GAME`, and select `Northstar release candidate`. Then, click the `UPDATE` button.
 
 **If you have installed a release candidate before**

--- a/cogs/PlaytesterPing.py
+++ b/cogs/PlaytesterPing.py
@@ -60,8 +60,8 @@ class PlayTesterPing(commands.Cog):
         
     @commands.Cog.listener()
     async def on_message(self, message):
-        playtestPingChannel = self.bot.get_channel(1170820923113357343)
-        thunderstoreReleaseChannel = self.bot.get_channel(1170820797653336077)
+        playtestPingChannel = self.bot.get_channel(936678773150081055)
+        thunderstoreReleaseChannel = self.bot.get_channel(939573786355859498)
 
         if message.author == self.bot.user:
             return
@@ -81,7 +81,7 @@ class PlayTesterPing(commands.Cog):
                 embed.set_author(name="Northstar " + rcVersion, icon_url="https://avatars.githubusercontent.com/u/86304187")
                 
                 pingMessage = await playtestPingChannel.send(
-                    f"""<@&1170828808702673147>
+                    f"""<@&936669179359141908>
 There is a new Northstar release candidate, `{rcVersion}`. If you find any issues or have feedback, please inform us in the thread attached to this message.
 ## **Installation**:
 **If you have __not__ installed a release candidate before**

--- a/cogs/PlaytesterPing.py
+++ b/cogs/PlaytesterPing.py
@@ -87,7 +87,7 @@ There is a new Northstar release candidate, `{rcVersion}`. If you find any issue
 **If you have __not__ installed a release candidate before:**
 Go to settings in FlightCore, and enable testing release channels. After you've done that, go to the play tab, click the arrow next to `LAUNCH GAME`, and select `Northstar release candidate`. Then, click the `UPDATE` button.
 
-**If you have installed a release candidate before**
+**If you have installed a release candidate before:**
 Make sure your release channel is still set to `Northstar release candidate`, and click the `UPDATE` button.""",
                     embed=embed
                 )

--- a/cogs/PlaytesterPing.py
+++ b/cogs/PlaytesterPing.py
@@ -18,6 +18,7 @@ def getLatestDiscussion():
             discussions(first: 1 categoryId: "DIC_kwDOGkM8Yc4CN-04") {
                 edges { 
                     node {
+                        url
                         body
                     }
                 }
@@ -36,6 +37,7 @@ def getLatestDiscussion():
     
     discussion_post = {
         'body': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["body"],
+        'url': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["url"]
     }
     
     return discussion_post
@@ -88,7 +90,9 @@ There is a new Northstar release candidate, `{rcVersion}`. If you find any issue
 Go to settings in FlightCore, and enable testing release channels. After you've done that, go to the play tab, click the arrow next to `LAUNCH GAME`, and select `Northstar release candidate`. Then, click the `UPDATE` button.
 
 **If you have installed a release candidate before:**
-Make sure your release channel is still set to `Northstar release candidate`, and click the `UPDATE` button.""",
+Make sure your release channel is still set to `Northstar release candidate`, and click the `UPDATE` button.
+## **Release Notes**:
+<{data["url"]}>""",
                     embed=embed
                 )
                 await pingMessage.create_thread(name=rcVersion)

--- a/cogs/PlaytesterPing.py
+++ b/cogs/PlaytesterPing.py
@@ -15,17 +15,10 @@ def getLatestDiscussion():
     query = """
     query {
         repository(owner: "R2Northstar", name: "Northstar") {
-            discussions(first: 1) {
+            discussions(first: 1 categoryId: "DIC_kwDOGkM8Yc4CN-04") {
                 edges { 
                     node {
-                        author {
-                            login
-                            url
-                        }
-                        title
-                        number
                         body
-                        url
                     }
                 }
             }
@@ -42,11 +35,7 @@ def getLatestDiscussion():
         return None
     
     discussion_post = {
-        'author': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["author"]["login"],
-        'title': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["title"],
         'body': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["body"],
-        'number': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["number"],
-        'url': raw_data["data"]["repository"]["discussions"]["edges"][0]["node"]["url"]
     }
     
     return discussion_post
@@ -71,8 +60,8 @@ class PlayTesterPing(commands.Cog):
         
     @commands.Cog.listener()
     async def on_message(self, message):
-        playtestPingChannel = self.bot.get_channel(936678773150081055)
-        thunderstoreReleaseChannel = self.bot.get_channel(939573786355859498)
+        playtestPingChannel = self.bot.get_channel(1170820923113357343)
+        thunderstoreReleaseChannel = self.bot.get_channel(1170820797653336077)
 
         if message.author == self.bot.user:
             return
@@ -92,10 +81,14 @@ class PlayTesterPing(commands.Cog):
                 embed.set_author(name="Northstar " + rcVersion, icon_url="https://avatars.githubusercontent.com/u/86304187")
                 
                 pingMessage = await playtestPingChannel.send(
-                    f"""<@&936669179359141908>, there is a new Northstar release candidate, `{rcVersion}`. If you find any issues or have feedback, please inform us in the thread attached to this message.
+                    f"""<@&1170828808702673147>
+There is a new Northstar release candidate, `{rcVersion}`. If you find any issues or have feedback, please inform us in the thread attached to this message.
+## **Installation**:
+**If you have __not__ installed a release candidate before**
+Go to settings in FlightCore, and enable testing release channels. After you've done that, go to the play tab, click the arrow next to `LAUNCH GAME`, and select `Northstar release candidate`. Then, click the `UPDATE` button.
 
-**Installation**:
-Go to settings in FlightCore, and enable testing release channels (you only need to do this once). After you've done that, go to the play tab, click the arrow next to `LAUNCH GAME`, and select `Northstar release candidate`. Then, click the `UPDATE` button.""",
+**If you have installed a release candidate before**
+Make sure your release channel is still set to `Northstar release candidate`, and click the `UPDATE` button.""",
                     embed=embed
                 )
                 await pingMessage.create_thread(name=rcVersion)


### PR DESCRIPTION
The function `getLatestDiscussion()` now gets the newest discussion from the  "Draft patch notes" category specifically, and only gets the body of that discussion.

I also changed the playtester ping message, and in my opinion, it now looks better.

![image](https://github.com/itscynxx/Spectre/assets/77130743/2b47cb03-3d2a-40ab-ba98-a2b15ef71c53)
